### PR TITLE
Fix stats mapstructure decoding

### DIFF
--- a/runtime/stats.go
+++ b/runtime/stats.go
@@ -60,7 +60,16 @@ func (s *SingleRuntime) GetStats() (models.NativeStats, error) {
 		}
 
 		var st models.NativeStatStats
-		err := mapstructure.WeakDecode(data, &st)
+		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			Result:           &st,
+			WeaklyTypedInput: true,
+			TagName:          "json",
+		})
+		if err != nil {
+			continue
+		}
+
+		err = decoder.Decode(data)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
Config mapstructure to use json tags for decoding to properly match CSV
field names.
This fixes fields such as Hrsp2xx that were not populated.