### PR TITLE
BUG/MEDIUM: runtime: Add quit to commands sent to master socket

### DIFF
--- a/runtime/runtime_single_client.go
+++ b/runtime/runtime_single_client.go
@@ -76,7 +76,7 @@ func (s *SingleRuntime) readFromSocket(command string) (string, error) {
 	}
 	fullCommand := fmt.Sprintf("set severity-output number;%s\n", command)
 	if s.worker > 0 {
-		fullCommand = fmt.Sprintf("@%v set severity-output number;@%v %s\n", s.worker, s.worker, command)
+		fullCommand = fmt.Sprintf("@%v set severity-output number;@%v %s;quit\n", s.worker, s.worker, command)
 	}
 	_, err = api.Write([]byte(fullCommand))
 	if err != nil {


### PR DESCRIPTION
The client native was looping over the output on the master socket
expecting an EOF to break out of the for loop. The master socket does
not send this EOF unless a "quit" is appended to force a disconnect.

Without sending this "quit" any Runtime API commands that are sent will
just hang until a timeout is reached at which point they will output the
below error:
[
    {
        "error": "timeout reached",
        "runtimeAPI": "/tmp/master.sock"
    }
]

This commit appends a ";quit" command to all commands sent to the master
socket causing the master socket to send an EOF as expected.