### PR TITLE
BUG/MEDIUM: defaults: Fix panic reflect for http-reuse

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1447,7 +1447,7 @@ func setFieldValue(section parser.Section, sectionName string, fieldName string,
 				return nil
 			}
 
-			b := field.Elem().String()
+			b := field.String()
 			d := types.HTTPReuse{
 				ShareType: b,
 			}


### PR DESCRIPTION
When attempting to update the value of http-reuse within the defaults
section a panic reflect error is encountered:

Panic reflect: call of reflect.Value.Elem on string Value:
client-native/configuration/configuration.go:1450 setFieldValue

This commit fix #33 by removing the Elem() call on field and replacing
with just String().