### PR TITLE
BUG/MINOR: frontend: Fix stats enable directive

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -847,7 +847,7 @@ func setFieldValue(section parser.Section, sectionName string, fieldName string,
 
 		if opt.StatsEnable {
 			s := &stats.OneWord{
-				Name: "enabled",
+				Name: "enable",
 			}
 			ss = append(ss, s)
 		}


### PR DESCRIPTION
Currently when setting "stats_enable" to true it is adding the
line "stats enabled" to the haproxy config. This should really be
"stats enable". This patch fixes #36.