### PR TITLE
BUG/MINOR Detect partial read from socket

### DIFF
--- a/runtime/runtime_single_client.go
+++ b/runtime/runtime_single_client.go
@@ -16,6 +16,7 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -101,7 +102,17 @@ func (s *SingleRuntime) readFromSocket(command string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	result := strings.TrimSuffix(data.String(), "\n> ")
+
+	// Check that last 2 bytes are a LF, otherwise we received an incomplete response
+	result := data.String()
+	if len(result) > 2 {
+		if result[len(result)-2:] != "\n\n" {
+			err := errors.New("Incomplete read from socket")
+			return result, err
+		}
+	}
+
+	result = strings.TrimSuffix(result, "\n> ")
 	result = strings.TrimSuffix(result, "\n")
 	return result, nil
 }


### PR DESCRIPTION
It's possible if an external process causes a reload/restart of HAProxy
that the data from the socket will be truncated. If it is not trucated
on a new line then other functions processing the results will have
malformed data and likely cause a panic.

Resolves haproxytech/client-native#44