### PR TITLE
FEATURE/MINOR: runtime: add acl support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/renameio v0.1.1-0.20200217212219-353f81969824
 	github.com/google/uuid v1.1.1
 	github.com/haproxytech/config-parser/v3 v3.0.0-rc1.0.20201218192213-cf1331eaac44
-	github.com/haproxytech/models/v2 v2.1.1-0.20201231125426-fddb29589894
+	github.com/haproxytech/models/v2 v2.2.0-rc1.0.20210112080933-32de531b38f2
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.2.2
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/haproxytech/config-parser/v3 v3.0.0-rc1.0.20201218192213-cf1331eaac44
 github.com/haproxytech/config-parser/v3 v3.0.0-rc1.0.20201218192213-cf1331eaac44/go.mod h1:68k+xwy1wGoufI/VKOOilrx/65M85eeQP6Atg+a29Ds=
 github.com/haproxytech/models/v2 v2.1.1-0.20201231125426-fddb29589894 h1:eOYpkqLCvlAhzEhjfN1OBzH0/quJm8R8DMpOxnjvCwY=
 github.com/haproxytech/models/v2 v2.1.1-0.20201231125426-fddb29589894/go.mod h1:HjM8x+j1/j4nHUA5lqh159OPZ3zQ5iGz13vHo9xeEk0=
+github.com/haproxytech/models/v2 v2.2.0-rc1.0.20210112080933-32de531b38f2 h1:cJfX3CNxOcZ7FW3pB88IxJfczdHBEG/dZ25A8JrQr78=
+github.com/haproxytech/models/v2 v2.2.0-rc1.0.20210112080933-32de531b38f2/go.mod h1:HjM8x+j1/j4nHUA5lqh159OPZ3zQ5iGz13vHo9xeEk0=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/runtime/acls.go
+++ b/runtime/acls.go
@@ -1,0 +1,214 @@
+package runtime
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	native_errors "github.com/haproxytech/client-native/v2/errors"
+	"github.com/haproxytech/models/v2"
+)
+
+// ShowACLS returns Acl files description from runtime
+func (s *SingleRuntime) ShowACLS() (models.ACLFiles, error) {
+	response, err := s.ExecuteWithResponse("show acl")
+	if err != nil {
+		return nil, fmt.Errorf("%s %w", err.Error(), native_errors.ErrNotFound)
+	}
+	return s.parseACLS(response), nil
+}
+
+// parseACLS parses output from `show acl` command and return array of acl files
+// First line in output represents format and is ignored
+// Sample output format:
+// # id (file) description
+// -0 (/etc/acl/blocklist.txt) pattern loaded from file '/etc/acl/blocklist.txt' used by acl at file '/usr/local/etc/haproxy/haproxy.cfg' line 59
+// -1 () acl 'src' file '/usr/local/etc/haproxy/haproxy.cfg' line 59
+func (s *SingleRuntime) parseACLS(output string) models.ACLFiles {
+	if output == "" {
+		return nil
+	}
+	acls := models.ACLFiles{}
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	for _, line := range lines {
+		m := s.parseACL(line)
+		if m != nil {
+			acls = append(acls, m)
+		}
+	}
+	return acls
+}
+
+// parseACL parses one line from ACL files array and return it structured
+func (s *SingleRuntime) parseACL(line string) *models.ACLFile {
+	if line == "" || strings.HasPrefix(strings.TrimSpace(line), "# id") {
+		return nil
+	}
+
+	parts := strings.Fields(line)
+	if len(parts) < 3 {
+		return nil
+	}
+
+	m := &models.ACLFile{
+		ID:          parts[0],
+		StorageName: findStorageName(line),
+		Description: strings.Join(parts[2:], " "),
+	}
+
+	return m
+}
+
+// findStorageName checks if acl name is existent and exctracts it
+func findStorageName(line string) string {
+	name := ""
+
+	parts := strings.Fields(line)
+	name = strings.TrimSuffix(strings.TrimPrefix(parts[1], "("), ")")
+
+	if name == "" {
+		re := regexp.MustCompile(`acl\s'(.*)'\sfile`)
+		matches := re.FindStringSubmatch(line)
+		if matches != nil {
+			name = matches[1]
+		}
+	}
+
+	return name
+}
+
+// GetACL returns one structured runtime Acl file
+func (s *SingleRuntime) GetACL(storageName string) (*models.ACLFile, error) {
+	if storageName == "" {
+		return nil, fmt.Errorf("%s %w", "Argument nameOrFile empty", native_errors.ErrGeneral)
+	}
+	acls, err := s.ShowACLS()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range acls {
+		if m.StorageName == storageName {
+			return m, nil
+		}
+	}
+	return nil, fmt.Errorf("%s %w", storageName, native_errors.ErrNotFound)
+}
+
+// ShowACLFileEntries returns one acl runtime entries
+func (s *SingleRuntime) ShowACLFileEntries(storageName string) (models.ACLFilesEntries, error) {
+	if storageName == "" {
+		return nil, fmt.Errorf("%s %w", "Argument file empty", native_errors.ErrGeneral)
+	}
+	cmd := fmt.Sprintf("show acl %s", storageName)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("%s %w", err.Error(), native_errors.ErrNotFound)
+	}
+	return ParseACLFileEntries(response, true)
+}
+
+// ParseACLFileEntries parses array of entries in one Acl file
+// One line sample entry:
+// ID			  Value
+// 0x560f3f9e8600 10.178.160.0
+func ParseACLFileEntries(output string, hasID bool) (models.ACLFilesEntries, error) {
+	if output == "" || strings.HasPrefix(strings.TrimSpace(output), "Unknown ACL identifier.") {
+		return nil, native_errors.ErrNotFound
+	}
+	me := models.ACLFilesEntries{}
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	for _, line := range lines {
+		e := parseACLFileEntry(line, hasID)
+		if e != nil {
+			me = append(me, e)
+		}
+	}
+	return me, nil
+}
+
+// parseACLFileEntry parses one entry in one Acl file/runtime and returns it structured
+func parseACLFileEntry(line string, hasID bool) *models.ACLFileEntry {
+	if line == "" || strings.HasPrefix(strings.TrimSpace(line), "#") {
+		return nil
+	}
+
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return nil
+	}
+
+	m := &models.ACLFileEntry{}
+	if hasID {
+		m.ID = parts[0] // acl entries from runtime have ID
+		m.Value = parts[1]
+	} else {
+		m.Value = parts[0]
+	}
+	return m
+}
+
+// AddACLFileEntry adds an entry into the Acl file
+func (s *SingleRuntime) AddACLFileEntry(aclID, value string) error {
+	if aclID == "" || value == "" {
+		return fmt.Errorf("%s %w", "One or more Arguments empty", native_errors.ErrGeneral)
+	}
+	m, _ := s.GetACLFileEntry(aclID, value)
+	if m != nil {
+		return fmt.Errorf("%w", native_errors.ErrAlreadyExists)
+	}
+	cmd := fmt.Sprintf("add acl #%s %s", aclID, value)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return fmt.Errorf("%s %w", err.Error(), native_errors.ErrGeneral)
+	}
+	if strings.Contains(response, "not") && strings.Contains(response, "valid") {
+		return fmt.Errorf("%s %w", strings.TrimSpace(response), native_errors.ErrGeneral)
+	}
+	return nil
+}
+
+// GetACLFileEntry returns one Acl runtime setting
+func (s *SingleRuntime) GetACLFileEntry(aclID, value string) (*models.ACLFileEntry, error) {
+	cmd := fmt.Sprintf("get acl #%s %s", aclID, value)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("%s %w", err.Error(), native_errors.ErrNotFound)
+	}
+
+	matched := false
+	m := &models.ACLFileEntry{}
+	parts := strings.Split(response, ",")
+	for _, p := range parts {
+		kv := strings.Split(p, "=")
+		switch key := strings.TrimSpace(kv[0]); {
+		case key == "pattern":
+			m.Value = strings.Trim(strings.TrimSpace(kv[1]), "\"")
+		case key == "match":
+			matched = true
+		}
+	}
+
+	if m.Value == "" || !matched {
+		return nil, fmt.Errorf("%s %w", value, native_errors.ErrNotFound)
+	}
+	return m, nil
+}
+
+// DeleteACLFileEntry deletes all the Acl entries from the Acl by its value
+func (s *SingleRuntime) DeleteACLFileEntry(aclID, value string) error {
+	if aclID == "" || value == "" {
+		return fmt.Errorf("%s %w", "One or more Arguments empty", native_errors.ErrGeneral)
+	}
+	cmd := fmt.Sprintf("del acl #%s %s", aclID, value)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return fmt.Errorf("%s %w", err.Error(), native_errors.ErrNotFound)
+	}
+	if strings.Contains(response, "not") && strings.Contains(response, "found") {
+		return fmt.Errorf("%s %w", strings.TrimSpace(response), native_errors.ErrGeneral)
+	}
+	return nil
+}

--- a/runtime/acls_test.go
+++ b/runtime/acls_test.go
@@ -1,0 +1,528 @@
+package runtime
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/haproxytech/models/v2"
+)
+
+func TestSingleRuntime_ShowACLS(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		socketPath string
+		worker     int
+		process    int
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		want           models.ACLFiles
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Simple show acl, should return 2 ACLFiles",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			want: models.ACLFiles{
+				&models.ACLFile{
+					StorageName: "/etc/acl/blocklist.txt",
+					Description: "pattern loaded from file '/etc/acl/blocklist.txt' used by acl at file '/usr/local/etc/haproxy/haproxy.cfg' line 59",
+					ID:          "0",
+				},
+				&models.ACLFile{
+					StorageName: "src",
+					Description: "acl 'src' file '/usr/local/etc/haproxy/haproxy.cfg' line 59",
+					ID:          "1",
+				},
+			},
+			socketResponse: map[string]string{
+				"show acl\n": ` # id (file) description
+				0 (/etc/acl/blocklist.txt) pattern loaded from file '/etc/acl/blocklist.txt' used by acl at file '/usr/local/etc/haproxy/haproxy.cfg' line 59
+				1 () acl 'src' file '/usr/local/etc/haproxy/haproxy.cfg' line 59
+				`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			got, err := s.ShowACLS()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.ShowACLS() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if !reflect.DeepEqual(got[i], tt.want[i]) {
+					t.Errorf("SingleRuntime.ShowACLS() = %v, want %v", got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_GetACL(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		nameOrFile string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		want           *models.ACLFile
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "get acl with file, should return blocklist.txt",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				nameOrFile: "/etc/acl/blocklist.txt",
+			},
+			want: &models.ACLFile{
+				StorageName: "/etc/acl/blocklist.txt",
+				Description: "pattern loaded from file '/etc/acl/blocklist.txt' used by acl at file '/usr/local/etc/haproxy/haproxy.cfg' line 59",
+				ID:          "0",
+			},
+			socketResponse: map[string]string{
+				"show acl\n": ` # id (file) description
+				0 (/etc/acl/blocklist.txt) pattern loaded from file '/etc/acl/blocklist.txt' used by acl at file '/usr/local/etc/haproxy/haproxy.cfg' line 59
+				1 () acl 'src' file '/usr/local/etc/haproxy/haproxy.cfg' line 59
+				`,
+			},
+		},
+		{
+			name:   "get acl with name, should return src",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				nameOrFile: "src",
+			},
+			want: &models.ACLFile{
+				StorageName: "src",
+				Description: "acl 'src' file '/usr/local/etc/haproxy/haproxy.cfg' line 59",
+				ID:          "1",
+			},
+			socketResponse: map[string]string{
+				"show acl\n": ` # id (file) description
+				0 (/etc/acl/blocklist.txt) pattern loaded from file '/etc/acl/blocklist.txt' used by acl at file '/usr/local/etc/haproxy/haproxy.cfg' line 59
+				1 () acl 'src' file '/usr/local/etc/haproxy/haproxy.cfg' line 59
+				`,
+			},
+		},
+		{
+			name:   "get acl with not existing name, should return nil and an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				nameOrFile: "something_not_existing",
+			},
+			want:    nil,
+			wantErr: true,
+			socketResponse: map[string]string{
+				"show acl\n": ` # id (file) description
+				0 (/etc/acl/blocklist.txt) pattern loaded from file '/etc/acl/blocklist.txt' used by acl at file '/usr/local/etc/haproxy/haproxy.cfg' line 59
+				1 () acl 'src' file '/usr/local/etc/haproxy/haproxy.cfg' line 59
+				`,
+			},
+		},
+		{
+			name:   "get acl with name, should return nil",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				nameOrFile: "",
+			},
+			want:           nil,
+			wantErr:        true,
+			socketResponse: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			got, err := s.GetACL(tt.args.nameOrFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.GetACL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SingleRuntime.GetACL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_ShowACLFileEntries(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		file string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		want           models.ACLFilesEntries
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "show acl with file, should 3 ACLFileEntries",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				file: "/etc/acl/blocklist.txt",
+			},
+			want: models.ACLFilesEntries{
+				&models.ACLFileEntry{
+					ID:    "0x55c476034560",
+					Value: "2.178.160.0/20",
+				},
+				&models.ACLFileEntry{
+					ID:    "0x55c475f602f0",
+					Value: "2.178.176.0/20",
+				},
+				&models.ACLFileEntry{
+					ID:    "0x55c476035b90",
+					Value: "2.178.192.0/20",
+				},
+			},
+			socketResponse: map[string]string{
+				"show acl /etc/acl/blocklist.txt\n": ` 0x55c476034560 2.178.160.0/20
+				0x55c475f602f0 2.178.176.0/20
+				0x55c476035b90 2.178.192.0/20
+				`,
+			},
+		},
+		{
+			name:   "show acl with wrong file, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				file: "src",
+			},
+			want:    nil,
+			wantErr: true,
+			socketResponse: map[string]string{
+				"show acl src\n": ` Unknown ACL identifier. Please use #<id> or <file>.
+				`,
+			},
+		},
+		{
+			name:   "show acl with file, should 3 ACLFileEntries",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				file: "",
+			},
+			want:           nil,
+			wantErr:        true,
+			socketResponse: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			got, err := s.ShowACLFileEntries(tt.args.file)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.ShowACLFileEntries() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if !reflect.DeepEqual(got[i], tt.want[i]) {
+					t.Errorf("SingleRuntime.ShowACLS() = %v, want %v", got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_GetACLFileEntry(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		aclID string
+		value string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		want           *models.ACLFileEntry
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "get acl entry, should find it",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				aclID: "0",
+				value: "2.178.160.0",
+			},
+			want: &models.ACLFileEntry{
+				Value: "2.178.160.0/20",
+			},
+			socketResponse: map[string]string{
+				"get acl #0 2.178.160.0\n": ` type=ip, case=sensitive, match=yes, idx=tree, pattern="2.178.160.0/20"
+				`,
+			},
+		},
+		{
+			name:   "get not existing acl entry, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				aclID: "0",
+				value: "2.0.0.1/24",
+			},
+			want:    nil,
+			wantErr: true,
+			socketResponse: map[string]string{
+				"get acl #1 2.0.0.1/24\n": ` type=ip, case=sensitive, match=no
+				`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			got, err := s.GetACLFileEntry(tt.args.aclID, tt.args.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.GetACLFileEntry() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SingleRuntime.GetACLFileEntry() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_AddACLFileEntry(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		aclID string
+		value string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "add acl entry, should work",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				aclID: "0",
+				value: "2.0.0.1/24",
+			},
+			wantErr: false,
+			socketResponse: map[string]string{
+				"get acl #0 2.0.0.1/24\n": ` type=ip, case=sensitive, match=no
+				`,
+				"add acl #0 2.0.0.1/24\n": `
+				`,
+			},
+		},
+		{
+			name:   "add invalid acl entry, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				aclID: "0",
+				value: "2.0.0.500/24",
+			},
+			wantErr: true,
+			socketResponse: map[string]string{
+				"get acl #0 2.0.0.500/24\n": ` type=ip, case=sensitive, match=no
+				`,
+				"add acl #0 2.0.0.500/24\n": ` '2.0.0.500/24' is not a valid IPv4 or IPv6 address.
+				`,
+			},
+		},
+		{
+			name:   "add already existing acl entry, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				aclID: "0",
+				value: "2.178.160.0",
+			},
+			wantErr: true,
+			socketResponse: map[string]string{
+				"get acl #0 2.178.160.0\n": ` type=ip, case=sensitive, match=yes, idx=tree, pattern="2.178.160.0/20"
+				`,
+			},
+		},
+		{
+			name:   "missing aclID, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				aclID: "",
+				value: "2.0.0.500/24",
+			},
+			wantErr:        true,
+			socketResponse: nil,
+		},
+		{
+			name:   "missing value, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				aclID: "0",
+				value: "",
+			},
+			wantErr:        true,
+			socketResponse: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			if err := s.AddACLFileEntry(tt.args.aclID, tt.args.value); (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.AddACLFileEntry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_DeleteACLFileEntry(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		aclID string
+		value string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "delete acl entry, should work",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				aclID: "0",
+				value: "2.0.0.1/24",
+			},
+			wantErr: false,
+			socketResponse: map[string]string{
+				"del acl #0 2.0.0.1/24\n": `
+				`,
+			},
+		},
+		{
+			name:   "delete acl entry not existing, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				aclID: "0",
+				value: "10.0.0.0/24",
+			},
+			wantErr: true,
+			socketResponse: map[string]string{
+				"del acl #0 10.0.0.0/24\n": ` Key not found.
+				`,
+			},
+		},
+		{
+			name:   "missing aclID, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				aclID: "",
+				value: "2.0.0.1/24",
+			},
+			wantErr:        true,
+			socketResponse: nil,
+		},
+		{
+			name:   "missing value, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				aclID: "0",
+				value: "",
+			},
+			wantErr:        true,
+			socketResponse: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			if err := s.DeleteACLFileEntry(tt.args.aclID, tt.args.value); (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.DeleteACLFileEntry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/runtime/haproxy_mock.go
+++ b/runtime/haproxy_mock.go
@@ -1,0 +1,102 @@
+package runtime
+
+import (
+	"bufio"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"strings"
+	"testing"
+)
+
+// HAProxyMock - Mock HAProxy Server for testing the socket communication
+type HAProxyMock struct {
+	net.Listener
+	running   bool
+	responses map[string]string
+	t         *testing.T
+}
+
+// NewHAProxyMock - create new haproxy mock
+func NewHAProxyMock(t *testing.T) *HAProxyMock {
+	haProxyMock := &HAProxyMock{}
+	haProxyMock.t = t
+	l, err := net.Listen("unix", socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	haProxyMock.Listener = l
+	return haProxyMock
+}
+
+// Stop - stop mock
+func (haproxy *HAProxyMock) Stop() {
+	haproxy.running = false
+}
+
+// Start - start mock
+func (haproxy *HAProxyMock) Start() {
+	haproxy.running = true
+	go func() {
+		for {
+			if !haproxy.running {
+				return
+			}
+			conn, err := haproxy.Accept()
+			if err != nil {
+				haproxy.t.Error(err)
+				return
+			}
+			haproxy.handleConnection(conn)
+		}
+	}()
+}
+
+// SetResponses - setting the expected repsonses
+func (haproxy *HAProxyMock) SetResponses(responses *map[string]string) {
+	haproxy.responses = *responses
+}
+
+func (haproxy *HAProxyMock) handleConnection(conn net.Conn) {
+	go func() {
+		defer func() {
+			_ = conn.Close()
+		}()
+
+		r := bufio.NewReader(conn)
+		w := bufio.NewWriter(conn)
+		s, err := r.ReadString('\n')
+		if err != nil && err != io.EOF {
+			haproxy.t.Log(err)
+			return
+		}
+
+		split := strings.Split(s, ";")
+		if len(split) > 0 {
+			s = split[len(split)-1]
+		}
+		response := haproxy.responses[s]
+		_, err = w.WriteString(response)
+		if err != nil {
+			haproxy.t.Log(err)
+			return
+		}
+		err = w.Flush()
+		if err != nil {
+			haproxy.t.Log(err)
+			return
+		}
+	}()
+}
+
+func socket() string {
+	f, err := ioutil.TempFile("", "haproxy-sock")
+	if err != nil {
+		panic(err)
+	}
+	addr := f.Name()
+	_ = f.Close()
+	_ = os.Remove(addr)
+	return addr
+}


### PR DESCRIPTION
Hi haproxy maintainers,

I played around with your cool runtime client and I noticed that currently it is not possible to add acl entires to a file which we need to maintain dynamically.

Therefore I created `acls.go` similar to `maps.go`. So it's possible to execute followed commands:
```
show acl
show acl %s
get acl #%s %s
add acl #%s %s
del acl #%s %s
```

It seems the [models/alc.go](https://github.com/haproxytech/models/blob/ea0dd4a520f93b8617fab64379f9dd68f6ef9af5/acl.go) is created for the configuration and not for the runtime. I created new local types. In case you are interested for this PR I can also create a PR to add these types to the model repo.

I look forward to your feedback.

Regards,
Thomas

PS: I also noticed that there are no tests for the runtime. So I tested the functionality with the followed coding:
```
package main

import (
	"log"

	"github.com/haproxytech/client-native/v2/runtime"
)

func main() {
	client := runtime.SingleRuntime{}
	err := client.Init("/etc/haproxy/socket/stats.sock", 0, 0)
	if err != nil {
		log.Println(err)
		return
	}

	// show all acls
	acls, err := client.ShowACLS()
	if err != nil {
		log.Println(err)
		return
	}
	for _, acl := range acls {
		log.Println(*acl)
	}

	// query for a specific acl with name
	acl, err := client.GetACL("src")
	if err != nil {
		log.Println(err)
		return
	}
	log.Println(acl)

	// query all file entries of acls with files
	lastACLFile := ""
	for _, acl := range acls {
		if acl.File != "" {
			lastACLFile = acl.File
			log.Printf("Found acl loaded form file '%s'", acl.File)
			aclFileEntries, err := client.ShowACLFileEntries(acl.File)
			if err != nil {
				log.Println(err)
			}
			if len(aclFileEntries) != 0 {
				log.Println("with followed entries: ")
				for _, entry := range aclFileEntries {
					log.Println(entry)
				}
			}
		}
	}

	// query acl with file
	acl, err = client.GetACL(lastACLFile)
	if err != nil {
		log.Println(err)
		return
	}
	log.Println(acl)

	// add acl entry
	err = client.AddACLFileEntry(acl.ID, "10.10.10.1")
	if err != nil {
		log.Println(err)
		return
	}

	// check if specific entry exists
	entry, err := client.GetACLFileEntry(acl.ID, "10.10.10.1")
	if err != nil {
		log.Println(err)
		return
	}
	if entry != nil {
		log.Println(entry)
	}

	// delete specific entry
	err = client.DeleteACLFileEntry(acl.ID, "10.10.10.1")
	if err != nil {
		log.Println(err)
		return
	}
}
```

