### PR TITLE
MINOR: service: Enable health checks

### DIFF
--- a/configuration/service.go
+++ b/configuration/service.go
@@ -305,6 +305,7 @@ func (s *Service) updateConfig() (bool, error) {
 				Address: node.address,
 				Port:    &node.port,
 				Weight:  misc.Int64P(128),
+				Check:   "enabled",
 			}
 			if node.disabled {
 				server.Maintenance = "enabled"


### PR DESCRIPTION
To avoid sending traffic to unhealthy servers that are found using service discovery health checks should be enabled.