### PR TITLE
BUG/MEDIUM: bind: fix ssl-min-ver serialization

### DIFF
--- a/configuration/bind.go
+++ b/configuration/bind.go
@@ -549,7 +549,7 @@ func SerializeBind(b models.Bind) types.Bind {
 		bind.Params = append(bind.Params, &params.BindOptionValue{Name: "ssl-max-ver", Value: b.SslMaxVer})
 	}
 	if b.SslMinVer != "" {
-		bind.Params = append(bind.Params, &params.BindOptionValue{Name: "ssl-min-ver", Value: b.SslMaxVer})
+		bind.Params = append(bind.Params, &params.BindOptionValue{Name: "ssl-min-ver", Value: b.SslMinVer})
 	}
 	if b.StrictSni {
 		bind.Params = append(bind.Params, &params.ServerOptionWord{Name: "strict-sni"})

--- a/configuration/bind_test.go
+++ b/configuration/bind_test.go
@@ -99,6 +99,8 @@ func TestCreateEditDeleteBind(t *testing.T) {
 		Ssl:            true,
 		SslCertificate: "dummy.crt",
 		Verify:         "optional",
+		SslMinVer:      "TLSv1.3",
+		SslMaxVer:      "TLSv1.3",
 	}
 
 	err := client.CreateBind("test", l, "", version)
@@ -138,6 +140,8 @@ func TestCreateEditDeleteBind(t *testing.T) {
 		Port:           &port,
 		Transparent:    true,
 		TCPUserTimeout: &tOut,
+		SslMinVer:      "TLSv1.2",
+		SslMaxVer:      "TLSv1.3",
 	}
 
 	err = client.EditBind("created", "test", l, "", version)


### PR DESCRIPTION
The `ssl-min-ver` bind option is incorrectly serialized. This change fixes the issue.