### PR TITLE
MINOR: runtime: add ssl crt-list/cert support

### DIFF
--- a/runtime/certs.go
+++ b/runtime/certs.go
@@ -1,0 +1,243 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	native_errors "github.com/haproxytech/client-native/v2/errors"
+	"github.com/haproxytech/models/v2"
+)
+
+type SslCertEntries []*SslCertEntry
+type SslCertEntry struct {
+	StorageName             string
+	Status                  string
+	Serial                  string
+	NotBefore               time.Time
+	NotAfter                time.Time
+	SubjectAlternativeNames []string
+	Algorithm               string
+	SHA1FingerPrint         string
+	Subject                 string
+	Issuer                  string
+	ChainSubject            string
+	ChainIssuer             string
+}
+
+// ShowCerts returns Certs files description from runtime
+func (s *SingleRuntime) ShowCerts() (models.SslCertificates, error) {
+	cmd := fmt.Sprintf("show ssl cert")
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("%s %w", err.Error(), native_errors.ErrNotFound)
+	}
+	return s.parseCerts(response), nil
+}
+
+// parseCerts parses output from `show cert` command and return array of certificates
+// First line in output represents format and is ignored
+// Sample output format:
+// /etc/ssl/cert-0.pem
+// /etc/ssl/...
+//
+func (s *SingleRuntime) parseCerts(output string) models.SslCertificates {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil
+	}
+	certs := models.SslCertificates{}
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		c := s.parseCert(line)
+		if c != nil {
+			certs = append(certs, c)
+		}
+	}
+	return certs
+}
+
+// parseCert parses one line from cert files array and return it structured
+func (s *SingleRuntime) parseCert(line string) *models.SslCertificate {
+	if line == "" || strings.HasPrefix(strings.TrimSpace(line), "# filename") {
+		return nil
+	}
+	split := strings.Split(line, "/")
+	cert := &models.SslCertificate{
+		StorageName: strings.TrimSpace(line),
+		Description: split[len(split)-1],
+	}
+	return cert
+}
+
+// GetCert returns one structured runtime certs
+func (s *SingleRuntime) GetCert(storageName string) (*models.SslCertificate, error) {
+	if storageName == "" {
+		return nil, fmt.Errorf("%s %w", "Argument storageName empty", native_errors.ErrGeneral)
+	}
+	certs, err := s.ShowCerts()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range certs {
+		if c.StorageName == storageName {
+			return c, nil
+		}
+	}
+	return nil, fmt.Errorf("%s %w", storageName, native_errors.ErrNotFound)
+}
+
+// ShowCertEntry returns one CrtList runtime entries
+func (s *SingleRuntime) ShowCertEntry(storageName string) (*SslCertEntry, error) {
+	if storageName == "" {
+		return nil, fmt.Errorf("%s %w", "Argument storageName empty", native_errors.ErrGeneral)
+	}
+	cmd := fmt.Sprintf("show ssl cert %s", storageName)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("%s %w", err.Error(), native_errors.ErrNotFound)
+	}
+	return parseCertEntry(response)
+}
+
+// parseCertEntry parses one entry in one CrtList file/runtime and returns it structured
+// example:
+// Filename: /etc/ssl/cert-2.pem
+// Status: Used
+// Serial: 0D933C1B1089BF660AE5253A245BB388
+// notBefore: Sep  9 00:00:00 2020 GMT
+// notAfter: Sep 14 12:00:00 2021 GMT
+// Subject Alternative Name: DNS:*.platform.domain.com, DNS:uaa.platform.domain.com
+// Algorithm: RSA4096
+// SHA1 FingerPrint: 59242F1838BDEF3E7DAFC83FFE4DD6C03B88805C
+// Subject: /C=DE/ST=Baden-Württemberg/L=Walldorf/O=ORG SE/CN=*.platform.domain.com
+// Issuer: /C=US/O=DigiCert Inc/CN=DigiCert SHA2 Secure Server CA
+// Chain Subject: /C=US/O=DigiCert Inc/CN=DigiCert SHA2 Secure Server CA
+// Chain Issuer: /C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert Global Root CA
+func parseCertEntry(response string) (*SslCertEntry, error) {
+	if response == "" || strings.HasPrefix(strings.TrimSpace(response), "#") {
+		return nil, native_errors.ErrNotFound
+	}
+
+	c := &SslCertEntry{}
+	parts := strings.Split(response, "\n")
+	for _, p := range parts {
+		index := strings.Index(p, ":")
+		if index == -1 {
+			continue
+		}
+		keyString := strings.TrimSpace(p[0:index])
+		valueString := strings.TrimSpace(p[index+1:])
+
+		switch key := keyString; {
+		case key == "Filename":
+			c.StorageName = valueString
+		case key == "Status":
+			c.Status = valueString
+		case key == "Serial":
+			c.Serial = valueString
+		case key == "notBefore":
+			c.NotBefore, _ = time.Parse("Jan 2 15:04:05 2006 MST", valueString)
+		case key == "notAfter":
+			c.NotAfter, _ = time.Parse("Jan 2 15:04:05 2006 MST", valueString)
+		case key == "Subject Alternative Name":
+			c.SubjectAlternativeNames = strings.Split(valueString, ", ")
+		case key == "Algorithm":
+			c.Algorithm = valueString
+		case key == "SHA1 FingerPrint":
+			c.SHA1FingerPrint = valueString
+		case key == "Subject":
+			c.Subject = valueString
+		case key == "Issuer":
+			c.Issuer = valueString
+		case key == "Chain Subject":
+			c.ChainSubject = valueString
+		case key == "Chain Issuer":
+			c.ChainIssuer = valueString
+		}
+	}
+
+	return c, nil
+}
+
+// NewCertEntry adds an entry into the CrtList file
+func (s *SingleRuntime) NewCertEntry(storageName string) error {
+	if storageName == "" {
+		return fmt.Errorf("%s %w", "Argument storageName empty", native_errors.ErrGeneral)
+	}
+	cmd := fmt.Sprintf("new ssl cert %s", storageName)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return fmt.Errorf("%s %w", err.Error(), native_errors.ErrGeneral)
+	}
+	if !strings.Contains(response, "New empty certificate store") {
+		return fmt.Errorf("%s %w", response, native_errors.ErrGeneral)
+	}
+	return nil
+}
+
+// SetCertEntry adds an entry into the CrtList file
+func (s *SingleRuntime) SetCertEntry(storageName string, payload string) error {
+	if storageName == "" || payload == "" {
+		return fmt.Errorf("%s %w", "Argument storageName or payload empty", native_errors.ErrGeneral)
+	}
+	cmd := fmt.Sprintf("set ssl cert %s <<\n%s\n", storageName, payload)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return fmt.Errorf("%s %w", err.Error(), native_errors.ErrGeneral)
+	}
+	if !strings.Contains(response, "Transaction created for certificate") {
+		return fmt.Errorf("%s %w", response, native_errors.ErrGeneral)
+	}
+	return nil
+}
+
+// CommitCertEntry adds an entry into the CrtList file
+func (s *SingleRuntime) CommitCertEntry(storageName string) error {
+	if storageName == "" {
+		return fmt.Errorf("%s %w", "Argument storageName empty", native_errors.ErrGeneral)
+	}
+	cmd := fmt.Sprintf("commit ssl cert %s", storageName)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return fmt.Errorf("%s %w", err.Error(), native_errors.ErrGeneral)
+	}
+	if !(strings.Contains(response, "Committing") && strings.Contains(response, "Success!")) {
+		return fmt.Errorf("%s %w", response, native_errors.ErrGeneral)
+	}
+	return nil
+}
+
+// AbortCertEntry adds an entry into the CrtList file
+func (s *SingleRuntime) AbortCertEntry(storageName string) error {
+	if storageName == "" {
+		return fmt.Errorf("%s %w", "Argument storageName empty", native_errors.ErrGeneral)
+	}
+	cmd := fmt.Sprintf("abort ssl cert %s", storageName)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return fmt.Errorf("%s %w", err.Error(), native_errors.ErrGeneral)
+	}
+	if !strings.Contains(response, "Transaction aborted for certificate") {
+		return fmt.Errorf("%s %w", response, native_errors.ErrGeneral)
+	}
+	return nil
+}
+
+// DeleteCertEntry adds an entry into the CrtList file
+func (s *SingleRuntime) DeleteCertEntry(storageName string) error {
+	if storageName == "" {
+		return fmt.Errorf("%s %w", "Argument storageName empty", native_errors.ErrGeneral)
+	}
+	cmd := fmt.Sprintf("del ssl cert %s", storageName)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return fmt.Errorf("%s %w", err.Error(), native_errors.ErrGeneral)
+	}
+	if !(strings.Contains(response, "Certificate") && strings.Contains(response, "deleted!")) {
+		return fmt.Errorf("%s %w", response, native_errors.ErrGeneral)
+	}
+	return nil
+}

--- a/runtime/certs_test.go
+++ b/runtime/certs_test.go
@@ -1,0 +1,619 @@
+package runtime
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/haproxytech/models/v2"
+)
+
+func TestSingleRuntime_ShowCerts(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		socketPath string
+		worker     int
+		process    int
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		want           models.SslCertificates
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Simple show certs, should return 3 files",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			want: models.SslCertificates{
+				&models.SslCertificate{
+					StorageName: "/etc/ssl/cert-0.pem",
+					Description: "cert-0.pem",
+				},
+				&models.SslCertificate{
+					StorageName: "/etc/ssl/cert-1.pem",
+					Description: "cert-1.pem",
+				},
+				&models.SslCertificate{
+					StorageName: "/etc/ssl/cert-2.pem",
+					Description: "cert-2.pem",
+				},
+			},
+			socketResponse: map[string]string{
+				"show ssl cert\n": ` # filename
+					/etc/ssl/cert-0.pem
+					/etc/ssl/cert-1.pem
+					/etc/ssl/cert-2.pem				
+				`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			got, err := s.ShowCerts()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.ShowCerts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if !reflect.DeepEqual(got[i], tt.want[i]) {
+					t.Errorf("SingleRuntime.ShowCrtLists() = %v, want %v", got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_GetCert(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		storageName string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		want           *models.SslCertificate
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Get certs, should return a cert",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/cert-0.pem",
+			},
+			want: &models.SslCertificate{
+				StorageName: "/etc/ssl/cert-0.pem",
+				Description: "cert-0.pem",
+			},
+			socketResponse: map[string]string{
+				"show ssl cert\n": ` # filename
+					/etc/ssl/cert-0.pem
+					/etc/ssl/cert-1.pem
+					/etc/ssl/cert-2.pem				
+				`,
+			},
+		},
+		{
+			name:   "Get unknown certs, should return a cert",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/cert-36.pem",
+			},
+			want:    nil,
+			wantErr: true,
+			socketResponse: map[string]string{
+				"show ssl cert\n": ` # filename
+					/etc/ssl/cert-0.pem
+					/etc/ssl/cert-1.pem
+					/etc/ssl/cert-2.pem				
+				`,
+			},
+		},
+		{
+			name:   "Get certs with empty argument, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "",
+			},
+			want:           nil,
+			wantErr:        true,
+			socketResponse: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			got, err := s.GetCert(tt.args.storageName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.GetCert() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SingleRuntime.GetCert() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_ShowCertEntry(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	notBefore, _ := time.Parse("Jan 2 15:04:05 2006 MST", "Sep  9 00:00:00 2020 GMT")
+	notAfter, _ := time.Parse("Jan 2 15:04:05 2006 MST", "Sep 14 12:00:00 2021 GMT")
+	type fields struct {
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		storageName string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		want           *SslCertEntry
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Simple show certs, should return a cert",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/cert-0.pem",
+			},
+			want: &SslCertEntry{
+				StorageName: "/etc/ssl/cert-0.pem",
+				Status:      "Used",
+				Serial:      "0D933C1B1089BF660AE5253A245BB388",
+				NotBefore:   notBefore,
+				NotAfter:    notAfter,
+				SubjectAlternativeNames: []string{
+					"DNS:*.platform.domain.com",
+					"DNS:uaa.platform.domain.com",
+				},
+				Algorithm:       "RSA4096",
+				SHA1FingerPrint: "59242F1838BDEF3E7DAFC83FFE4DD6C03B88805C",
+				Subject:         "/C=DE/ST=Baden-Württemberg/L=Walldorf/O=ORG SE/CN=*.platform.domain.com",
+				Issuer:          "/C=US/O=DigiCert Inc/CN=DigiCert SHA2 Secure Server CA",
+				ChainSubject:    "/C=US/O=DigiCert Inc/CN=DigiCert SHA2 Secure Server CA",
+				ChainIssuer:     "/C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert Global Root CA",
+			},
+			socketResponse: map[string]string{
+				"show ssl cert /etc/ssl/cert-0.pem\n": ` Filename: /etc/ssl/cert-0.pem
+					Status: Used
+					Serial: 0D933C1B1089BF660AE5253A245BB388
+					notBefore: Sep  9 00:00:00 2020 GMT
+					notAfter: Sep 14 12:00:00 2021 GMT
+					Subject Alternative Name: DNS:*.platform.domain.com, DNS:uaa.platform.domain.com
+					Algorithm: RSA4096
+					SHA1 FingerPrint: 59242F1838BDEF3E7DAFC83FFE4DD6C03B88805C
+					Subject: /C=DE/ST=Baden-Württemberg/L=Walldorf/O=ORG SE/CN=*.platform.domain.com
+					Issuer: /C=US/O=DigiCert Inc/CN=DigiCert SHA2 Secure Server CA
+					Chain Subject: /C=US/O=DigiCert Inc/CN=DigiCert SHA2 Secure Server CA
+					Chain Issuer: /C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert Global Root CA							
+				`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			got, err := s.ShowCertEntry(tt.args.storageName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.ShowCertEntries() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SingleRuntime.ShowCertEntries() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_NewCertEntry(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		jobs       chan Task
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		storageName string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Create new cert, should return no error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/new_cert.pem",
+			},
+			wantErr: false,
+			socketResponse: map[string]string{
+				"new ssl cert /etc/ssl/new_cert.pem\n": ` New empty certificate store '/etc/ssl/new_cert.pem'!				
+				`,
+			},
+		},
+		{
+			name:   "Create new cert without storageName, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "",
+			},
+			wantErr:        true,
+			socketResponse: nil,
+		},
+		{
+			name:   "Create new cert which already exists, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/existing_cert.pem",
+			},
+			wantErr: true,
+			socketResponse: map[string]string{
+				"new ssl cert /etc/ssl/existing_cert.pem\n": ` Certificate '/etc/ssl/existing_cert.pem' already exists!				
+				`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			if err := s.NewCertEntry(tt.args.storageName); (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.NewCertEntry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_SetCertEntry(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		jobs       chan Task
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		storageName string
+		payload     string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Create new cert, should return no error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/new_cert.pem",
+				payload:     "-----BEGIN CERTIFICATE-----<redacted>...",
+			},
+			wantErr: false,
+			socketResponse: map[string]string{
+				"set ssl cert /etc/ssl/new_cert.pem <<\n-----BEGIN CERTIFICATE-----<redacted>...\n": ` Transaction created for certificate /etc/ssl/new_cert.pem!				
+				`,
+			},
+		},
+		{
+			name:   "Create new cert, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/wrong_cert.pem",
+				payload:     "-----BEGIN CERTIFICATE-----<redacted_wrong_cert>...",
+			},
+			wantErr: true,
+			socketResponse: map[string]string{
+				"set ssl cert /etc/ssl/wrong_cert.pem <<\n-----BEGIN CERTIFICATE-----<redacted_wrong_cert>...\n": ` unable to load certificate from file 'wrong_cert.pem'.
+					Can't load the payload
+					Can't update wrong_cert.pem!									
+					`,
+			},
+		},
+		{
+			name:   "Create new cert, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/wrong_cert.pem",
+				payload:     "",
+			},
+			wantErr:        true,
+			socketResponse: map[string]string{},
+		},
+		{
+			name:   "Create new cert, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "",
+				payload:     "-----BEGIN CERTIFICATE-----<redacted>...",
+			},
+			wantErr:        true,
+			socketResponse: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			if err := s.SetCertEntry(tt.args.storageName, tt.args.payload); (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.SetCertEntry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_CommitCertEntry(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		jobs       chan Task
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		storageName string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Commit updated cert, should return no error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/updated_cert.pem",
+			},
+			wantErr: false,
+			socketResponse: map[string]string{
+				"commit ssl cert /etc/ssl/updated_cert.pem\n": ` Committing /etc/ssl/updated_cert.pem"
+				Success!								
+				`,
+			},
+		},
+		{
+			name:   "Commit incomplete cert, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/incomplete_cert.pem",
+			},
+			wantErr: true,
+			socketResponse: map[string]string{
+				"commit ssl cert /etc/ssl/incomplete_cert.pem\n": ` The transaction must contain at least a certificate and a private key!
+				Can't commit /etc/ssl/incomplete_cert.pem!
+				`,
+			},
+		},
+		{
+			name:   "Commit without storageName, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "",
+			},
+			wantErr:        true,
+			socketResponse: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			if err := s.CommitCertEntry(tt.args.storageName); (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.CommitCertEntry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_AbortCertEntry(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		jobs       chan Task
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		storageName string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Abort updated cert, should return no error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/updated_cert.pem",
+			},
+			wantErr: false,
+			socketResponse: map[string]string{
+				"abort ssl cert /etc/ssl/updated_cert.pem\n": ` Transaction aborted for certificate '/etc/ssl/updated_cert.pem'!
+				`,
+			},
+		},
+		{
+			name:   "Abort cert no transaction exists, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/no_transaction_cert.pem",
+			},
+			wantErr: true,
+			socketResponse: map[string]string{
+				"abort ssl cert /etc/ssl/no_transaction_cert.pem\n": ` No ongoing transaction!
+				`,
+			},
+		},
+		{
+			name:   "Abort without storageName, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "",
+			},
+			wantErr:        true,
+			socketResponse: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			if err := s.AbortCertEntry(tt.args.storageName); (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.AbortCertEntry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_DeleteCertEntry(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		jobs       chan Task
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		storageName string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Delete cert, should return no error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/delete_cert.pem",
+			},
+			wantErr: false,
+			socketResponse: map[string]string{
+				"del ssl cert /etc/ssl/delete_cert.pem\n": ` Certificate '/etc/ssl/delete_cert.pem' deleted!				
+				`,
+			},
+		},
+		{
+			name:   "Delete cert without storageName, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "",
+			},
+			wantErr:        true,
+			socketResponse: nil,
+		},
+		{
+			name:   "Delete cert which not exists, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				storageName: "/etc/ssl/not_existing_cert.pem",
+			},
+			wantErr: true,
+			socketResponse: map[string]string{
+				"del ssl cert /etc/ssl/not_existing_cert.pem\n": ` Can't remove the certificate: certificate '/etc/ssl/not_existing_cert.pem' doesn't exist!				
+				`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			if err := s.DeleteCertEntry(tt.args.storageName); (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.DeleteCertEntry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/runtime/crt-lists.go
+++ b/runtime/crt-lists.go
@@ -1,0 +1,174 @@
+package runtime
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	native_errors "github.com/haproxytech/client-native/v2/errors"
+)
+
+type CrtLists []*CrtList
+
+type CrtList struct {
+	File string
+}
+
+type CrtListEntries []*CrtListEntry
+
+type CrtListEntry struct {
+	LineNumber    int
+	File          string
+	SSLBindConfig string
+	SNIFilter     []string
+}
+
+// ShowCrtLists returns CrtList files description from runtime
+func (s *SingleRuntime) ShowCrtLists() (CrtLists, error) {
+	response, err := s.ExecuteWithResponse("show ssl crt-list")
+	if err != nil {
+		return nil, fmt.Errorf("%s %w", err.Error(), native_errors.ErrNotFound)
+	}
+	return s.parseCrtLists(response), nil
+}
+
+// parseCrtLists parses output from `show crt-list` command and return array of crt-list files
+// First line in output represents format and is ignored
+// Sample output format:
+// /etc/ssl/crt-list
+// /etc/ssl/...
+//
+func (s *SingleRuntime) parseCrtLists(output string) CrtLists {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil
+	}
+	crtLists := CrtLists{}
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		c := s.parseCrtList(line)
+		if c != nil {
+			crtLists = append(crtLists, c)
+		}
+	}
+	return crtLists
+}
+
+// parseCrtList parses one line from CrtList files array and return it structured
+func (s *SingleRuntime) parseCrtList(line string) *CrtList {
+	if line == "" {
+		return nil
+	}
+	crtList := &CrtList{
+		File: line,
+	}
+	return crtList
+}
+
+// GetCrtList returns one structured runtime CrtList file
+func (s *SingleRuntime) GetCrtList(file string) (*CrtList, error) {
+	crtLists, err := s.ShowCrtLists()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range crtLists {
+		if m.File == file {
+			return m, nil
+		}
+	}
+	return nil, fmt.Errorf("%s %w", file, native_errors.ErrNotFound)
+}
+
+// ShowCrtListEntries returns one CrtList runtime entries
+func (s *SingleRuntime) ShowCrtListEntries(file string) (CrtListEntries, error) {
+	cmd := fmt.Sprintf("show ssl crt-list -n %s", file)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("%s %w", err.Error(), native_errors.ErrNotFound)
+	}
+	return ParseCrtListEntries(response)
+}
+
+// ParseCrtListEntries parses array of entries in one CrtList file
+// One line sample entry:
+// /etc/ssl/cert-0.pem !*.crt-test.platform.domain.com !connectivitynotification.platform.domain.com !connectivitytunnel.platform.domain.com !authentication.cert.another.domain.com !*.authentication.cert.another.domain.com
+// /etc/ssl/cert-1.pem [verify optional ca-file /etc/ssl/ca-file-1.pem] *.crt-test.platform.domain.com !connectivitynotification.platform.domain.com !connectivitytunnel.platform.domain.com !authentication.cert.another.domain.com !*.authentication.cert.another.domain.com
+// /etc/ssl/cert-2.pem [verify required ca-file /etc/ssl/ca-file-2.pem]
+func ParseCrtListEntries(output string) (CrtListEntries, error) {
+	output = strings.TrimSpace(output)
+	if output == "" || strings.HasPrefix(output, "didn't find the specified filename") {
+		return nil, native_errors.ErrNotFound
+	}
+	ce := CrtListEntries{}
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	for _, line := range lines {
+		entry := parseCrtListEntry(line)
+		if entry != nil {
+			ce = append(ce, entry)
+		}
+	}
+	return ce, nil
+}
+
+// parseCrtListEntry parses one entry in one CrtList file/runtime and returns it structured
+// example:
+// cert1.pem
+// cert2.pem [alpn h2,http/1.1]
+// certW.pem                   *.domain.tld !secure.domain.tld
+// certS.pem [curves X25519:P-256 ciphers ECDHE-ECDSA-AES256-GCM-SHA384] secure.domain.tld
+func parseCrtListEntry(line string) *CrtListEntry {
+	if line == "" || strings.HasPrefix(strings.TrimSpace(line), "#") {
+		return nil
+	}
+
+	c := &CrtListEntry{}
+	re := regexp.MustCompile(`(\S+)(?:\s\[(.*)\])?(?:\s(.*))?`)
+	matches := re.FindStringSubmatch(line)
+	if matches != nil {
+		split := strings.Split(matches[1], ":")
+		linenumber, _ := strconv.ParseInt(split[1], 0, 32)
+		c.LineNumber = int(linenumber)
+		c.File = split[0]
+		c.SSLBindConfig = matches[2]
+		c.SNIFilter = strings.Fields(matches[3])
+	}
+
+	return c
+}
+
+// AddCrtListEntry adds an entry into the CrtList file
+func (s *SingleRuntime) AddCrtListEntry(crtList string, entry CrtListEntry) error {
+	cmd := fmt.Sprintf("add ssl crt-list %s <<\n%s", crtList, entry.File)
+	if entry.SSLBindConfig != "" {
+		cmd = fmt.Sprintf("%s [%s]", cmd, entry.SSLBindConfig)
+	}
+	for _, sni := range entry.SNIFilter {
+		cmd = fmt.Sprintf("%s %s", cmd, sni)
+	}
+	cmd += "\n"
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return fmt.Errorf("%s %w", err.Error(), native_errors.ErrGeneral)
+	}
+	if !strings.Contains(response, "Success") {
+		return fmt.Errorf("%s %w", response, native_errors.ErrGeneral)
+	}
+	return nil
+}
+
+// DeleteCrtListEntry deletes all the CrtList entries from the CrtList by its id
+func (s *SingleRuntime) DeleteCrtListEntry(crtList, certFile string, lineNumber int) error {
+	cmd := fmt.Sprintf("del ssl crt-list %s %s:%v", crtList, certFile, lineNumber)
+	response, err := s.ExecuteWithResponse(cmd)
+	if err != nil {
+		return fmt.Errorf("%s %w", err.Error(), native_errors.ErrNotFound)
+	}
+	if !strings.Contains(response, "deleted in crtlist") {
+		return fmt.Errorf("%s %w", response, native_errors.ErrGeneral)
+	}
+	return nil
+}

--- a/runtime/crt-lists_test.go
+++ b/runtime/crt-lists_test.go
@@ -1,0 +1,415 @@
+package runtime
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSingleRuntime_ShowCrtLists(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		socketPath string
+		worker     int
+		process    int
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		want           CrtLists
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Simple show crt-list files, should return a file",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			want: CrtLists{
+				&CrtList{
+					File: "/etc/haproxy/crt-list",
+				},
+			},
+			socketResponse: map[string]string{
+				"show ssl crt-list\n": ` /etc/haproxy/crt-list
+				`,
+			},
+		},
+		{
+			name:   "Simple show crt-list files, should return a nothing",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			want:   nil,
+			socketResponse: map[string]string{
+				"show ssl crt-list\n": `
+				`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			got, err := s.ShowCrtLists()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.ShowCrtLists() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if !reflect.DeepEqual(got[i], tt.want[i]) {
+					t.Errorf("SingleRuntime.ShowCrtLists() = %v, want %v", got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_GetCrtList(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		file string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		want           *CrtList
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Get specific crt-list files, should return a file",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				file: "/etc/haproxy/crt-list",
+			},
+			want: &CrtList{
+				File: "/etc/haproxy/crt-list",
+			},
+			socketResponse: map[string]string{
+				"show ssl crt-list\n": ` /etc/haproxy/crt-list
+				`,
+			},
+		},
+		{
+			name:   "Get a not known crt-list files, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				file: "/etc/haproxy/not-known-list",
+			},
+			want:    nil,
+			wantErr: true,
+			socketResponse: map[string]string{
+				"show ssl crt-list\n": ` /etc/haproxy/crt-list
+				`,
+			},
+		},
+		{
+			name:   "Get a no crt-list files, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				file: "/etc/haproxy/crt-list",
+			},
+			want:    nil,
+			wantErr: true,
+			socketResponse: map[string]string{
+				"show ssl crt-list\n": `
+				`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			got, err := s.GetCrtList(tt.args.file)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.GetCrtList() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SingleRuntime.GetCrtList() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_ShowCrtListEntries(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		jobs       chan Task
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		file string
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		want           CrtListEntries
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "Get crt-list entries of crt-list file, should return 3 entries",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				file: "/etc/haproxy/crt-list",
+			},
+			want: CrtListEntries{
+				&CrtListEntry{
+					LineNumber: 1,
+					File:       "/etc/ssl/cert-0.pem",
+					SNIFilter: []string{
+						"!*.crt-test.platform.domain.com",
+						"!connectivitynotification.platform.domain.com",
+						"!connectivitytunnel.platform.domain.com",
+						"!authentication.cert.another.domain.com",
+						"!*.authentication.cert.another.domain.com",
+					},
+				},
+				&CrtListEntry{
+					LineNumber:    2,
+					File:          "/etc/ssl/cert-1.pem",
+					SSLBindConfig: "verify optional ca-file /etc/ssl/ca-file-1.pem",
+					SNIFilter: []string{
+						"*.crt-test.platform.domain.com",
+						"!connectivitynotification.platform.domain.com",
+					},
+				},
+				&CrtListEntry{
+					LineNumber:    4,
+					File:          "/etc/ssl/cert-2.pem",
+					SSLBindConfig: "verify required ca-file /etc/ssl/ca-file-2.pem",
+					SNIFilter:     []string{},
+				},
+			},
+			socketResponse: map[string]string{
+				"show ssl crt-list -n /etc/haproxy/crt-list\n": ` # /etc/ssl/crt-list
+					/etc/ssl/cert-0.pem:1 !*.crt-test.platform.domain.com !connectivitynotification.platform.domain.com !connectivitytunnel.platform.domain.com !authentication.cert.another.domain.com !*.authentication.cert.another.domain.com
+					/etc/ssl/cert-1.pem:2 [verify optional ca-file /etc/ssl/ca-file-1.pem] *.crt-test.platform.domain.com !connectivitynotification.platform.domain.com 
+					/etc/ssl/cert-2.pem:4 [verify required ca-file /etc/ssl/ca-file-2.pem]
+				`,
+			},
+		},
+		{
+			name:   "Get crt-list entries of crt-list file, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				file: "/etc/haproxy/not_known_list",
+			},
+			want:    nil,
+			wantErr: true,
+			socketResponse: map[string]string{
+				"show ssl crt-list -n /etc/haproxy/not_known_list\n": ` didn't find the specified filename
+				`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			got, err := s.ShowCrtListEntries(tt.args.file)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.ShowCrtListEntries() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if !reflect.DeepEqual(got[i], tt.want[i]) {
+					t.Errorf("SingleRuntime.ShowCrtListEntries() = %v, want %v", got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_AddCrtListEntry(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		jobs       chan Task
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		crtList string
+		entry   CrtListEntry
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "add crt-list entries to crt-list file, should return no error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				crtList: "/etc/haproxy/crt-list",
+				entry: CrtListEntry{
+					File:          "/etc/ssl/cert-0.pem",
+					SSLBindConfig: "alpn h2",
+					SNIFilter: []string{
+						"test.domain.com",
+					},
+				},
+			},
+			wantErr: false,
+			socketResponse: map[string]string{
+				"add ssl crt-list /etc/haproxy/crt-list <<\n/etc/ssl/cert-0.pem [alpn h2] test.domain.com\n": ` Inserting certificate '/etc/ssl/cert-0.pem' in crt-list '/etc/ssl/crt-list'.
+				Success!
+				`,
+			},
+		},
+		{
+			name:   "add crt-list entries to crt-list file without SSLBindConfig, should return no error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				crtList: "/etc/haproxy/crt-list",
+				entry: CrtListEntry{
+					File: "/etc/ssl/cert-0.pem",
+					SNIFilter: []string{
+						"test.domain.com",
+					},
+				},
+			},
+			wantErr: false,
+			socketResponse: map[string]string{
+				"add ssl crt-list /etc/haproxy/crt-list <<\n/etc/ssl/cert-0.pem test.domain.com\n": ` Inserting certificate '/etc/ssl/cert-0.pem' in crt-list '/etc/ssl/crt-list'.
+				Success!
+				`,
+			},
+		},
+		{
+			name:   "add crt-list entries to crt-list file with a not known pem, should return an error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				crtList: "/etc/haproxy/crt-list",
+				entry: CrtListEntry{
+					File:      "/etc/ssl/not_known.pem",
+					SNIFilter: []string{},
+				},
+			},
+			wantErr: true,
+			socketResponse: map[string]string{
+				"add ssl crt-list /etc/haproxy/crt-list <<\n/etc/ssl/not_known.pem\n": ` Can't edit the crt-list: certificate '/etc/ssl/cert-26.pem' does not exist!
+				`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			if err := s.AddCrtListEntry(tt.args.crtList, tt.args.entry); (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.AddCrtListEntry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSingleRuntime_DeleteCrtListEntry(t *testing.T) {
+	haProxy := NewHAProxyMock(t)
+	haProxy.Start()
+	defer haProxy.Stop()
+
+	type fields struct {
+		jobs       chan Task
+		socketPath string
+		worker     int
+		process    int
+	}
+	type args struct {
+		crtList    string
+		certFile   string
+		lineNumber int
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantErr        bool
+		socketResponse map[string]string
+	}{
+		{
+			name:   "delete crt-list entries of crt-list, should return no error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				crtList:    "/etc/haproxy/crt-list",
+				certFile:   "/etc/ssl/cert-1.pem",
+				lineNumber: 5,
+			},
+			wantErr: false,
+			socketResponse: map[string]string{
+				"del ssl crt-list /etc/haproxy/crt-list /etc/ssl/cert-1.pem:5\n": ` Entry '/etc/ssl/cert-1.pem' deleted in crtlist '/etc/ssl/crt-list'!
+				`,
+			},
+		},
+		{
+			name:   "delete crt-list entries of crt-list, should return no error",
+			fields: fields{socketPath: haProxy.Addr().String()},
+			args: args{
+				crtList:    "/etc/haproxy/crt-list",
+				certFile:   "/etc/ssl/not_known.pem",
+				lineNumber: 10,
+			},
+			wantErr: true,
+			socketResponse: map[string]string{
+				"del ssl crt-list /etc/haproxy/crt-list /etc/ssl/not_known.pem:10\n": ` Can't edit the crt-list: certificate '/etc/ssl/not_known.pem' does not exist!
+				`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haProxy.SetResponses(&tt.socketResponse)
+			s := &SingleRuntime{}
+			err := s.Init(tt.fields.socketPath, tt.fields.process, tt.fields.worker)
+			if err != nil {
+				t.Errorf("SingleRuntime.Init() error = %v", err)
+				return
+			}
+			if err := s.DeleteCrtListEntry(tt.args.crtList, tt.args.certFile, tt.args.lineNumber); (err != nil) != tt.wantErr {
+				t.Errorf("SingleRuntime.DeleteCrtListEntry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/test/HAProxyMock.go
+++ b/test/HAProxyMock.go
@@ -1,4 +1,4 @@
-package runtime
+package test
 
 import (
 	"bufio"
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -40,7 +39,7 @@ func (haproxy *HAProxyMock) Start() {
 	haproxy.running = true
 	go func() {
 		for {
-			if !haproxy.running {
+			if haproxy.running == false {
 				return
 			}
 			conn, err := haproxy.Accept()
@@ -72,15 +71,6 @@ func (haproxy *HAProxyMock) handleConnection(conn net.Conn) {
 			return
 		}
 
-		if strings.Contains(s, "<<") {
-			r, _ := r.ReadString('\n')
-			s += r
-		}
-
-		split := strings.Split(s, ";")
-		if len(split) > 0 {
-			s = split[len(split)-1]
-		}
 		response := haproxy.responses[s]
 		_, err = w.WriteString(response)
 		if err != nil {


### PR DESCRIPTION
Hi haproxy maintainers,

our plan was also to update our certs via socket as for the ACLs, therefore I created similar to #49 a pull request for the followed commands:

```
show ssl crt-list
add ssl crt-list %s <<\n%s
del ssl crt-list %s %s:%s

show ssl cert
new ssl cert %s
set ssl cert %s <<\n%s\n
commit ssl cert %s
abort ssl cert %s
del ssl cert %s
```
I could reuse the models.SslCertificates, but there are followed models missing:
```
SslCertEntry
SslCertEntries
CrtList
CrtLists
CrtListEntries
CrtListEntry 
```
If you are interested, I could also add these models.

I look forward to your feedback.

Regards,
Thomas

PS: Unfortunately we noticed that the CAs couldn't be updated via socket and so our use case is not complete. I created a feature request https://github.com/haproxy/haproxy/issues/1057