### PR TITLE
BUILD/MINOR: github: adding e2e action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,27 @@
 name: go test
 on: [push, pull_request]
-jobs:
 
+jobs:
+  e2e:
+    name: e2e on HAProxy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        haproxyVersion: [2.1, 2.2, 2.3]
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          file: ./e2e/Dockerfile
+          build-args: |
+            HAPROXY_VERSION=${{ matrix.haproxyVersion }}
+          tags: client-native-test:${{ matrix.haproxyVersion }}
+      - uses: addnab/docker-run-action@v2
+        with:
+          image: client-native-test:${{ matrix.haproxyVersion }}
+          run: go test -tags integration ./...
   tests:
     name: Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Providing e2e test suite using GitHub Actions.

The actual strategy matrix provides support for HAProxy 2.1, 2.2, and 2.3.