### PR TITLE
BUILD/MINOR: add client-native-swagger-server option in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,16 @@ models: spec
 		--build-arg UID=$(shell id -u) \
 		--build-arg GID=$(shell id -g) \
 		-t client-native-models .
-	docker run --rm -it -v "$(PWD)":/data client-native-models
+	docker run --rm -it -v ${PROJECT_PATH}:/data client-native-models
 	ls -lah models
+
+.PHONY: client-native-swagger-server
+client-native-swagger-server: spec
+	cd build/server;docker build \
+		--build-arg SWAGGER_VERSION=${SWAGGER_VERSION} \
+		--build-arg UID=$(shell id -u) \
+		--build-arg GID=$(shell id -g) \
+		-t client-native-swagger-server .
 
 .PHONY: lint
 lint:

--- a/build/server/Dockerfile
+++ b/build/server/Dockerfile
@@ -1,0 +1,19 @@
+ARG SWAGGER_VERSION=v0.23.0
+FROM quay.io/goswagger/swagger:$SWAGGER_VERSION
+
+ARG SPEC_URL=https://raw.githubusercontent.com/haproxytech/client-native/master/specification/build/haproxy_spec.yaml
+ARG UID
+ARG GID
+COPY script.sh .
+VOLUME ["/data"]
+
+RUN addgroup -g "$GID" -S docker && adduser -u "$UID" -S user -G docker && \
+    chmod +x ./script.sh && mkdir -p /docker-generation/dataplaneapi && \
+    echo "module github.com/haproxytech" | tee /docker-generation/go.mod && \
+    chown -R "${UID}:${GID}" /docker-generation && \
+    chown -R "${UID}:${GID}" /data && \
+    wget -O /docker-generation/copyright.txt https://raw.githubusercontent.com/haproxytech/client-native/master/specification/copyright.txt && \
+    wget -O /docker-generation/haproxy_spec.yaml "${SPEC_URL}"
+
+USER user
+ENTRYPOINT ["./script.sh"]

--- a/build/server/script.sh
+++ b/build/server/script.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+swagger version
+cp /data/configure_data_plane.go /docker-generation/dataplaneapi/configure_data_plane.go
+swagger generate server -f /docker-generation/haproxy_spec.yaml \
+    -A "Data Plane" \
+    -t /docker-generation/ \
+    --existing-models github.com/haproxytech/client-native/v2/models \
+    --exclude-main \
+    --skip-models \
+    -s dataplaneapi \
+    -r /docker-generation/copyright.txt
+rm /data/doc.go
+rm /data/embedded_spec.go
+rm /data/server.go
+rm -rf /data/operations/*
+cp -a /docker-generation/dataplaneapi/. /data


### PR DESCRIPTION
generated image can them be used in dataplane repo as
docker run --rm -it -v ${DATAPLANEAPI_PATH}:/data client-native-swagger-server