### PR TITLE
BUG/MINOR: Add rand.Seed() to RandomString()

### DIFF
--- a/misc/stringutil.go
+++ b/misc/stringutil.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var chars = []rune("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") //nolint:gochecknoglobals
@@ -199,6 +200,7 @@ func Int64P(i int) *int64 {
 }
 
 func RandomString(n int) string {
+	rand.Seed(time.Now().UnixNano())
 	b := make([]rune, n)
 	size := len(chars)
 	for i := range b {


### PR DESCRIPTION
When generating SRV names for service discovery mechanisms it's
very likely that multiple backends will end up with similar server
names. Even removing a backend and having it re-added will frequently
produce similar names that it had before removing it. The rand library
docs state that:

  "Top-level functions, such as Float64 and Int, use a
default shared Source that produces a deterministic sequence of values
each time a program is run. Use the Seed function to initialize the
default Source if different behavior is required for each run."

This patch adds a rand.Seed() to prevent the same names from being used
in different backends.

This fixes #66 