### PR TITLE
BUG/MEDIUM: config: Fix tcp-request connection silent-drop parsing

### DIFF
--- a/configuration/tcp_request_rule.go
+++ b/configuration/tcp_request_rule.go
@@ -516,6 +516,12 @@ func SerializeTCPRequestRule(f models.TCPRequestRule) (rule types.TCPType, err e
 				Cond:     f.Cond,
 				CondTest: f.CondTest,
 			}, nil
+		case models.TCPRequestRuleActionSilentDrop:
+			return &tcp_types.Connection{
+				Action:   &tcp_actions.SilentDrop{},
+				Cond:     f.Cond,
+				CondTest: f.CondTest,
+			}, nil
 		case models.TCPRequestRuleActionLua:
 			return &tcp_types.Connection{
 				Action: &tcp_actions.Lua{

--- a/configuration/tcp_request_rule_test.go
+++ b/configuration/tcp_request_rule_test.go
@@ -289,3 +289,52 @@ func TestCreateEditDeleteTCPRequestRule(t *testing.T) {
 		version++
 	}
 }
+
+func TestSerializeTCPRequestRule(t *testing.T) {
+	testCases := []struct {
+		input          models.TCPRequestRule
+		expectedResult string
+	}{
+		{
+			input: models.TCPRequestRule{
+				Type:     models.TCPRequestRuleTypeConnection,
+				Action:   models.TCPRequestRuleActionSilentDrop,
+				Cond:     "if",
+				CondTest: "FALSE",
+			},
+			expectedResult: "connection silent-drop if FALSE",
+		},
+		{
+			input: models.TCPRequestRule{
+				Type:     models.TCPRequestRuleTypeContent,
+				Action:   models.TCPRequestRuleActionSilentDrop,
+				Cond:     "if",
+				CondTest: "FALSE",
+			},
+			expectedResult: "content silent-drop if FALSE",
+		},
+		{
+			input: models.TCPRequestRule{
+				Type:     models.TCPRequestRuleTypeSession,
+				Action:   models.TCPRequestRuleActionSilentDrop,
+				Cond:     "if",
+				CondTest: "FALSE",
+			},
+			expectedResult: "session silent-drop if FALSE",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.expectedResult, func(t *testing.T) {
+			tcpType, err := SerializeTCPRequestRule(testCase.input)
+			if err != nil {
+				t.Error(err.Error())
+			}
+
+			actual := tcpType.String()
+			if actual != testCase.expectedResult {
+				t.Errorf("Expected %q, got: %q", testCase.expectedResult, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow up on https://github.com/haproxytech/client-native/pull/70

It appears that there are no tests to cover the https://github.com/haproxytech/client-native/blob/b1d1624dea70be1e352d3c32c5a8ee3bc3dbbfa0/configuration/tcp_request_rule.go#L439 function and I missed adding the `SilentDrop` action there