### PR TITLE
BUG/MEDIUM: config: Fix http-request-rule redirect code parsing

### DIFF
--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -108,6 +108,7 @@ frontend test
   http-request lua.foo param1 param2 if FALSE
   http-request use-service svrs if FALSE
   http-request return status 200 content-type "text/plain" string "My content" hdr Some-Header value if FALSE
+  http-request redirect scheme https if !{ ssl_fc }
   http-response allow if src 192.168.0.0/16
   http-response set-header X-SSL %[ssl_fc]
   http-response set-var(req.my_var) req.fhdr(user-agent),lower

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -109,6 +109,7 @@ frontend test
   http-request use-service svrs if FALSE
   http-request return status 200 content-type "text/plain" string "My content" hdr Some-Header value if FALSE
   http-request redirect scheme https if !{ ssl_fc }
+  http-request redirect location https://%[hdr(host),field(1,:)]:443%[capture.req.uri] code 302
   http-response allow if src 192.168.0.0/16
   http-response set-header X-SSL %[ssl_fc]
   http-response set-var(req.my_var) req.fhdr(user-agent),lower

--- a/configuration/http_request_rule.go
+++ b/configuration/http_request_rule.go
@@ -247,8 +247,10 @@ func ParseHTTPRequestRule(f types.HTTPAction) (rule *models.HTTPRequestRule, err
 	case *actions.Redirect:
 		var codePtr *int64
 		var code int64
-		if code, err = strconv.ParseInt(v.Code, 10, 64); err == nil {
-			codePtr = &code
+		if v.Code != "" {
+			if code, err = strconv.ParseInt(v.Code, 10, 64); err == nil {
+				codePtr = &code
+			}
 		}
 		rule = &models.HTTPRequestRule{
 			Type:        "redirect",
@@ -259,7 +261,6 @@ func ParseHTTPRequestRule(f types.HTTPAction) (rule *models.HTTPRequestRule, err
 			CondTest:    v.CondTest,
 			RedirCode:   codePtr,
 		}
-
 	case *actions.Tarpit:
 		var dsPtr *int64
 		var ds int64

--- a/configuration/http_request_rule_test.go
+++ b/configuration/http_request_rule_test.go
@@ -29,8 +29,8 @@ func TestGetHTTPRequestRules(t *testing.T) { //nolint:gocognit,gocyclo
 		t.Error(err.Error())
 	}
 
-	if len(hRules) != 30 {
-		t.Errorf("%v http request rules returned, expected 30", len(hRules))
+	if len(hRules) != 31 {
+		t.Errorf("%v http request rules returned, expected 31", len(hRules))
 	}
 
 	if v != version {
@@ -475,8 +475,32 @@ func TestGetHTTPRequestRules(t *testing.T) { //nolint:gocognit,gocyclo
 			if r.CondTest != "!{ ssl_fc }" {
 				t.Errorf("%v: CondTest not !{ ssl_fc }: %v", *r.Index, r.CondTest)
 			}
+		case 30:
+			if r.Type != "redirect" {
+				t.Errorf("%v: Type not redirect: %v", *r.Index, r.Type)
+			}
+			if r.RedirType != "location" {
+				t.Errorf("%v: RedirType not location: %v", *r.Index, r.RedirType)
+			}
+			if r.RedirValue != "https://%[hdr(host),field(1,:)]:443%[capture.req.uri]" {
+				t.Errorf("%v: RedirValue not match: %v", *r.Index, r.RedirValue)
+			}
+			if r.RedirCode == nil {
+				t.Errorf("%v: RedirCode not 302: %v", *r.Index, r.RedirCode)
+			} else if *r.RedirCode != 302 {
+				t.Errorf("%v: RedirCode not 302: %v", *r.Index, *r.RedirCode)
+			}
+			if r.RedirOption != "" {
+				t.Errorf("%v: RedirOption not empty: %v", *r.Index, r.RedirOption)
+			}
+			if r.Cond != "" {
+				t.Errorf("%v: Cond not empty: %v", *r.Index, r.Cond)
+			}
+			if r.CondTest != "" {
+				t.Errorf("%v: CondTest not empty: %v", *r.Index, r.CondTest)
+			}
 		default:
-			t.Errorf("Expext only http-request 0 to 29, %v found", *r.Index)
+			t.Errorf("Expext only http-request 0 to 30, %v found", *r.Index)
 		}
 	}
 
@@ -638,7 +662,7 @@ func TestCreateEditDeleteHTTPRequestRule(t *testing.T) {
 	}
 
 	// TestDeleteHTTPRequest
-	err = client.DeleteHTTPRequestRule(30, "frontend", "test", "", version)
+	err = client.DeleteHTTPRequestRule(31, "frontend", "test", "", version)
 	if err != nil {
 		t.Error(err.Error())
 	} else {
@@ -649,9 +673,9 @@ func TestCreateEditDeleteHTTPRequestRule(t *testing.T) {
 		t.Error("Version not incremented")
 	}
 
-	_, _, err = client.GetHTTPRequestRule(30, "frontend", "test", "")
+	_, _, err = client.GetHTTPRequestRule(31, "frontend", "test", "")
 	if err == nil {
-		t.Error("DeleteHTTPRequestRule failed, HTTP Request Rule 30 still exists")
+		t.Error("DeleteHTTPRequestRule failed, HTTP Request Rule 31 still exists")
 	}
 
 	err = client.DeleteHTTPRequestRule(2, "backend", "test_2", "", version)

--- a/configuration/http_request_rule_test.go
+++ b/configuration/http_request_rule_test.go
@@ -29,8 +29,8 @@ func TestGetHTTPRequestRules(t *testing.T) { //nolint:gocognit,gocyclo
 		t.Error(err.Error())
 	}
 
-	if len(hRules) != 29 {
-		t.Errorf("%v http request rules returned, expected 26", len(hRules))
+	if len(hRules) != 30 {
+		t.Errorf("%v http request rules returned, expected 30", len(hRules))
 	}
 
 	if v != version {
@@ -453,8 +453,30 @@ func TestGetHTTPRequestRules(t *testing.T) { //nolint:gocognit,gocyclo
 			if r.CondTest != "FALSE" {
 				t.Errorf("%v: CondTest not FALSE: %v", *r.Index, r.CondTest)
 			}
+		case 29:
+			if r.Type != "redirect" {
+				t.Errorf("%v: Type not redirect: %v", *r.Index, r.Type)
+			}
+			if r.RedirType != "scheme" {
+				t.Errorf("%v: RedirType not scheme: %v", *r.Index, r.RedirType)
+			}
+			if r.RedirValue != "https" {
+				t.Errorf("%v: RedirValue not https: %v", *r.Index, r.RedirValue)
+			}
+			if r.RedirCode != nil {
+				t.Errorf("%v: RedirCode not empty: %v", *r.Index, *r.RedirCode)
+			}
+			if r.RedirOption != "" {
+				t.Errorf("%v: RedirOption not empty: %v", *r.Index, r.RedirOption)
+			}
+			if r.Cond != "if" {
+				t.Errorf("%v: Cond not if: %v", *r.Index, r.Cond)
+			}
+			if r.CondTest != "!{ ssl_fc }" {
+				t.Errorf("%v: CondTest not !{ ssl_fc }: %v", *r.Index, r.CondTest)
+			}
 		default:
-			t.Errorf("Expext only http-request 0 to 28, %v found", *r.Index)
+			t.Errorf("Expext only http-request 0 to 29, %v found", *r.Index)
 		}
 	}
 
@@ -616,7 +638,7 @@ func TestCreateEditDeleteHTTPRequestRule(t *testing.T) {
 	}
 
 	// TestDeleteHTTPRequest
-	err = client.DeleteHTTPRequestRule(29, "frontend", "test", "", version)
+	err = client.DeleteHTTPRequestRule(30, "frontend", "test", "", version)
 	if err != nil {
 		t.Error(err.Error())
 	} else {
@@ -627,9 +649,9 @@ func TestCreateEditDeleteHTTPRequestRule(t *testing.T) {
 		t.Error("Version not incremented")
 	}
 
-	_, _, err = client.GetHTTPRequestRule(29, "frontend", "test", "")
+	_, _, err = client.GetHTTPRequestRule(30, "frontend", "test", "")
 	if err == nil {
-		t.Error("DeleteHTTPRequestRule failed, HTTP Request Rule 29 still exists")
+		t.Error("DeleteHTTPRequestRule failed, HTTP Request Rule 30 still exists")
 	}
 
 	err = client.DeleteHTTPRequestRule(2, "backend", "test_2", "", version)


### PR DESCRIPTION
Redirect code is an optional argument. If it is not declared in the config file, `ParseHTTPRequestRule` will return an ErrSyntax from `strconv.ParseInt`.