### PR TITLE
BUG/MEDIUM: config: Fix tcp-request connection expect-proxy serialisation

### DIFF
--- a/configuration/tcp_request_rule_test.go
+++ b/configuration/tcp_request_rule_test.go
@@ -322,6 +322,15 @@ func TestSerializeTCPRequestRule(t *testing.T) {
 			},
 			expectedResult: "session silent-drop if FALSE",
 		},
+		{
+			input: models.TCPRequestRule{
+				Type:     models.TCPRequestRuleTypeConnection,
+				Action:   models.TCPRequestRuleActionExpectProxy,
+				Cond:     "if",
+				CondTest: "{ src 1.2.3.4 5.6.7.8 }",
+			},
+			expectedResult: "connection expect-proxy layer4 if { src 1.2.3.4 5.6.7.8 }",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Without the change, the serialisation produces `connection expect-proxy layer4` instead of `connection expect-proxy layer4 if { src 1.2.3.4 5.6.7.8 }`