### PR TITLE
Fix incorrect example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ if err != nil {
 }
 
 runtimeClient := &runtime_api.Client{}
-globalConf, err := confClient.GetGlobalConfiguration("")
+_, globalConf, err := confClient.GetGlobalConfiguration("")
 if err == nil {
     socketList := make([]string, 0, 1)
     runtimeAPIs := globalConf.RuntimeApis

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ runtimeClient := &runtime_api.Client{}
 globalConf, err := confClient.GetGlobalConfiguration("")
 if err == nil {
     socketList := make([]string, 0, 1)
-    runtimeAPIs := globalConf.Data.RuntimeApis
+    runtimeAPIs := globalConf.RuntimeApis
 
     if len(runtimeAPIs) != 0 {
         for _, r := range runtimeAPIs {


### PR DESCRIPTION
First of all thank you for the client: it's a very useful software.

I tried to use an example from README.md and have met 2 errors:
1. GetGlobalConfiguration() currently returns 3 values: version, global configuration object and an error, but example uses 2 values
2. type ``*models.Global`` has no field or method Data