### PR TITLE
BUG/MINOR: make deny_status for http-request deny and tarpit optional

### DIFF
--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -110,6 +110,7 @@ frontend test
   http-request return status 200 content-type "text/plain" string "My content" hdr Some-Header value if FALSE
   http-request redirect scheme https if !{ ssl_fc }
   http-request redirect location https://%[hdr(host),field(1,:)]:443%[capture.req.uri] code 302
+  http-request deny unless src 192.168.0.0/16
   http-response allow if src 192.168.0.0/16
   http-response set-header X-SSL %[ssl_fc]
   http-response set-var(req.my_var) req.fhdr(user-agent),lower

--- a/configuration/http_request_rule.go
+++ b/configuration/http_request_rule.go
@@ -229,8 +229,10 @@ func ParseHTTPRequestRule(f types.Action) (rule *models.HTTPRequestRule, err err
 	case *http_actions.Deny:
 		var denyPtr *int64
 		var ds int64
-		if ds, err = strconv.ParseInt(v.DenyStatus, 10, 64); err == nil {
-			denyPtr = &ds
+		if v.DenyStatus != "" {
+			if ds, err = strconv.ParseInt(v.DenyStatus, 10, 64); err == nil {
+				denyPtr = &ds
+			}
 		}
 		rule = &models.HTTPRequestRule{
 			Type:       "deny",
@@ -265,8 +267,10 @@ func ParseHTTPRequestRule(f types.Action) (rule *models.HTTPRequestRule, err err
 	case *http_actions.Tarpit:
 		var dsPtr *int64
 		var ds int64
-		if ds, err = strconv.ParseInt(v.DenyStatus, 10, 64); err == nil {
-			dsPtr = &ds
+		if v.DenyStatus != "" {
+			if ds, err = strconv.ParseInt(v.DenyStatus, 10, 64); err == nil {
+				dsPtr = &ds
+			}
 		}
 		rule = &models.HTTPRequestRule{
 			Type:       "tarpit",

--- a/configuration/http_request_rule_test.go
+++ b/configuration/http_request_rule_test.go
@@ -29,7 +29,7 @@ func TestGetHTTPRequestRules(t *testing.T) { //nolint:gocognit,gocyclo
 		t.Error(err.Error())
 	}
 
-	if len(hRules) != 31 {
+	if len(hRules) != 32 {
 		t.Errorf("%v http request rules returned, expected 31", len(hRules))
 	}
 
@@ -499,8 +499,18 @@ func TestGetHTTPRequestRules(t *testing.T) { //nolint:gocognit,gocyclo
 			if r.CondTest != "" {
 				t.Errorf("%v: CondTest not empty: %v", *r.Index, r.CondTest)
 			}
+		case 31:
+			if r.Type != "deny" {
+				t.Errorf("%v: Type not deny: %v", *r.Index, r.Type)
+			}
+			if r.Cond != "unless" {
+				t.Errorf("%v: Cond not unless: %v", *r.Index, r.Cond)
+			}
+			if r.CondTest != "src 192.168.0.0/16" {
+				t.Errorf("%v: CondTest not src 192.168.0.0/16: %v", *r.Index, r.CondTest)
+			}
 		default:
-			t.Errorf("Expext only http-request 0 to 30, %v found", *r.Index)
+			t.Errorf("Expext only http-request 0 to 31, %v found", *r.Index)
 		}
 	}
 
@@ -673,7 +683,7 @@ func TestCreateEditDeleteHTTPRequestRule(t *testing.T) {
 		t.Error("Version not incremented")
 	}
 
-	_, _, err = client.GetHTTPRequestRule(31, "frontend", "test", "")
+	_, _, err = client.GetHTTPRequestRule(32, "frontend", "test", "")
 	if err == nil {
 		t.Error("DeleteHTTPRequestRule failed, HTTP Request Rule 31 still exists")
 	}


### PR DESCRIPTION
As documentation says ``deny_status`` for ``deny`` and ``tarpit`` ``http-request`` actions is optional, this PR makes it really optional and fixes bug described in #77.