### PR TITLE
Remove set severity-output number for non-worker process

### DIFF
--- a/runtime/runtime_single_client.go
+++ b/runtime/runtime_single_client.go
@@ -97,7 +97,7 @@ func (s *SingleRuntime) readFromSocket(command string) (string, error) {
 		return "", err
 	}
 
-	fullCommand := fmt.Sprintf("set severity-output number;%s\n", command)
+	fullCommand := fmt.Sprintf("%s\n", command)
 	if s.worker > 0 {
 		fullCommand = fmt.Sprintf("@%v set severity-output number;@%v %s;quit\n", s.worker, s.worker, command)
 	}


### PR DESCRIPTION
In master-worker mode, in at least version 2.2, the `set severity-output number` is not a valid command. 