### PR TITLE
Fix duplicate check-send-proxy option

### DIFF
--- a/configuration/server.go
+++ b/configuration/server.go
@@ -503,8 +503,8 @@ func SerializeServer(s models.Server) types.Server { //nolint:gocognit,gocyclo,c
 	if s.CheckSendProxy == "enabled" {
 		srv.Params = append(srv.Params, &params.ServerOptionWord{Name: "check-send-proxy"})
 	}
-	if s.CheckSendProxy == "enabled" {
-		srv.Params = append(srv.Params, &params.ServerOptionWord{Name: "check-send-proxy"})
+	if s.CheckSendProxy == "disabled" {
+		srv.Params = append(srv.Params, &params.ServerOptionWord{Name: "no-check-send-proxy"})
 	}
 	if s.CheckSsl == "enabled" {
 		srv.Params = append(srv.Params, &params.ServerOptionWord{Name: "check-ssl"})


### PR DESCRIPTION
Currently, if a server is created and `CheckSendProxy` is `enabled` then `check-send-proxy` appears twice:

```
backend test
  ...
  server testserver localhost:1337 check-send-proxy check-send-proxy send-proxy-v2
```

This seems to be a copy paste mistake.