### PR TITLE
BUG/MINOR: Remove erroneous space preventing parse of some bind params

### DIFF
--- a/configuration/bind.go
+++ b/configuration/bind.go
@@ -469,13 +469,13 @@ func serializeBindParams(b models.BindParams, path string) (options []params.Bin
 		options = append(options, &params.BindOptionValue{Name: "ca-sign-pass", Value: b.CaSignPass})
 	}
 	if b.Ciphers != "" {
-		options = append(options, &params.BindOptionValue{Name: "ciphers ", Value: b.Ciphers})
+		options = append(options, &params.BindOptionValue{Name: "ciphers", Value: b.Ciphers})
 	}
 	if b.Ciphersuites != "" {
-		options = append(options, &params.BindOptionValue{Name: "ciphersuites ", Value: b.Ciphersuites})
+		options = append(options, &params.BindOptionValue{Name: "ciphersuites", Value: b.Ciphersuites})
 	}
 	if b.CrlFile != "" {
-		options = append(options, &params.BindOptionValue{Name: "crl-file ", Value: b.CrlFile})
+		options = append(options, &params.BindOptionValue{Name: "crl-file", Value: b.CrlFile})
 	}
 	if b.CrtIgnoreErr != "" {
 		options = append(options, &params.BindOptionValue{Name: "crt-ignore-err", Value: b.CrtIgnoreErr})

--- a/configuration/bind_test.go
+++ b/configuration/bind_test.go
@@ -103,6 +103,9 @@ func TestCreateEditDeleteBind(t *testing.T) {
 			Verify:         "optional",
 			SslMinVer:      "TLSv1.3",
 			SslMaxVer:      "TLSv1.3",
+			Ciphers:        "ECDH+AESGCM:ECDH+CHACHA20",
+			Ciphersuites:   "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384",
+			CrlFile:        "dummy.crl",
 		},
 	}
 


### PR DESCRIPTION
There was a space in the name of a few parameters for binds that prevented the parsing of them back out of the configuration file. This was seen while using the Dataplane API. I've added these cases to the tests.