### PR TITLE
Enable race detection for CI and fix race bug

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -121,7 +121,7 @@ jobs:
       id: go
     - name: Test
       run: |
-        go test -v ./...
+        go test -race -v ./...
   e2e:
     name: e2e on HAProxy
     needs: ["go-test"]


### PR DESCRIPTION
This project should have race detector enabled in CI. 

There was a real data race in HAProxy mock that was fixed as well. Somewhat harmless today, but not enabling race detector can lead to unexpected problems in future.

Example of a race condition is available in commit: https://github.com/haproxytech/client-native/pull/96/commits/e9538cda1b8e21a172644671f71078d687ef9db2