### PR TITLE
BUG/MEDIUM: parser: fix: concurrent map writes

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -164,7 +164,9 @@ func (c *client) DeleteParser(transactionID string) error {
 	if !ok {
 		return NewConfError(ErrTransactionDoesNotExist, transactionID)
 	}
+	c.clientMu.Lock()
 	delete(c.parsers, transactionID)
+	c.clientMu.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
```
fatal error: concurrent map writes
goroutine 18653 [running]:
github.com/haproxytech/client-native/v5/configuration.(*client).DeleteParser(0xc003a72000, {0xc00211f830, 0x24})
        /home/runner/go/pkg/mod/github.com/haproxytech/client-native/v5@v5.0.2/configuration/configuration.go:155 +0x18f
github.com/haproxytech/client-native/v5/configuration.(*Transaction).DeleteTransaction(0xc003a72000, {0xc00211f830, 0x24})
        /home/runner/go/pkg/mod/github.com/haproxytech/client-native/v5@v5.0.2/configuration/transaction.go:438 +0x12e
github.com/haproxytech/client-native/v5/configuration.(*Transaction).ErrAndDeleteTransaction(...)
        /home/runner/go/pkg/mod/github.com/haproxytech/client-native/v5@v5.0.2/configuration/transaction.go:729
github.com/haproxytech/client-native/v5/configuration.(*Transaction).HandleError(0x3?, {0xc0040d2370, 0x30}, {0xc0040d23ad, 0x8}, {0xc0040d23c2, 0x34}, {0xc00211f830, 0x24}, 0x1, ...)
```