### PR TITLE
BUG/MINOR: add missing field when parsing backend `balance` field

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -961,6 +961,7 @@ func (s *SectionParser) balance() interface{} {
 		b.URIDepth = prm.Depth
 		b.URILen = prm.Len
 		b.URIWhole = prm.Whole
+		b.URIPathOnly = prm.PathOnly
 	case *params.BalanceURLParam:
 		b.URLParam = prm.Param
 		b.URLParamCheckPost = prm.CheckPost


### PR DESCRIPTION
When parsing a backend with the balance option set to `uri path-only`, the parameter `PathOnly` is ignored:

```go
func TestBalance(t *testing.T) {
	configFile, _ := os.CreateTemp("/tmp", "")
	_, _ = configFile.WriteString(`
		backend app
		    balance uri path-only
	`)

	config, _ := configuration.New(
		context.Background(),
		options.ConfigurationFile(configFile.Name()),
		options.HAProxyBin("echo"),
		options.TransactionsDir("/tmp"),
	)

	_, backend, _ := config.GetBackend("app", "")
	assert.True(t, backend.Balance.URIPathOnly)
}
```