### PR TITLE
allowedErrorCodes: adds '407 Proxy Authentication Required'.

### DIFF
--- a/config-parser/parsers/http/actions/return.go
+++ b/config-parser/parsers/http/actions/return.go
@@ -61,6 +61,7 @@ var allowedErrorCodes = map[int64]struct{}{ //nolint:gochecknoglobals
 	403: {},
 	404: {},
 	405: {},
+	407: {},
 	408: {},
 	410: {},
 	413: {},


### PR DESCRIPTION
Hey, team.
I've added a valid status code to the allowedErrorCodes map for proxy authentication as the program just removes the deny_status attribute in the configuration file otherwise.
Thank you.