### PR TITLE
MEDIUM: runtime: Add glitch metrics to stick table fields

### DIFF
--- a/models/stick_table.go
+++ b/models/stick_table.go
@@ -213,8 +213,8 @@ func (m *StickTable) UnmarshalBinary(b []byte) error {
 // swagger:model StickTableField
 type StickTableField struct {
 	// field
-	// Enum: ["bytes_in_cnt","bytes_in_rate","bytes_out_cnt","bytes_out_rate","conn_cnt","conn_cur","conn_rate","gpc0","gpc0_rate","gpc1","gpc1_rate","gpt0","http_req_cnt","http_req_rate","http_err_cnt","http_err_rate","server_id","sess_cnt","sess_rate"]
-	// +kubebuilder:validation:Enum=bytes_in_cnt;bytes_in_rate;bytes_out_cnt;bytes_out_rate;conn_cnt;conn_cur;conn_rate;gpc0;gpc0_rate;gpc1;gpc1_rate;gpt0;http_req_cnt;http_req_rate;http_err_cnt;http_err_rate;server_id;sess_cnt;sess_rate;
+	// Enum: ["bytes_in_cnt","bytes_in_rate","bytes_out_cnt","bytes_out_rate","conn_cnt","conn_cur","conn_rate","gpc0","gpc0_rate","gpc1","gpc1_rate","gpt0","http_req_cnt","http_req_rate","http_err_cnt","http_err_rate","server_id","sess_cnt","sess_rate","glitch_rate","glitch_cnt"]
+	// +kubebuilder:validation:Enum=bytes_in_cnt;bytes_in_rate;bytes_out_cnt;bytes_out_rate;conn_cnt;conn_cur;conn_rate;gpc0;gpc0_rate;gpc1;gpc1_rate;gpt0;http_req_cnt;http_req_rate;http_err_cnt;http_err_rate;server_id;sess_cnt;sess_rate;glitch_rate;glitch_cnt;
 	Field string `json:"field,omitempty"`
 
 	// period
@@ -248,7 +248,7 @@ var stickTableFieldTypeFieldPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["bytes_in_cnt","bytes_in_rate","bytes_out_cnt","bytes_out_rate","conn_cnt","conn_cur","conn_rate","gpc0","gpc0_rate","gpc1","gpc1_rate","gpt0","http_req_cnt","http_req_rate","http_err_cnt","http_err_rate","server_id","sess_cnt","sess_rate"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["bytes_in_cnt","bytes_in_rate","bytes_out_cnt","bytes_out_rate","conn_cnt","conn_cur","conn_rate","gpc0","gpc0_rate","gpc1","gpc1_rate","gpt0","http_req_cnt","http_req_rate","http_err_cnt","http_err_rate","server_id","sess_cnt","sess_rate","glitch_rate","glitch_cnt"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -314,6 +314,12 @@ const (
 
 	// StickTableFieldFieldSessRate captures enum value "sess_rate"
 	StickTableFieldFieldSessRate string = "sess_rate"
+
+	// StickTableFieldFieldGlitchRate captures enum value "glitch_rate"
+	StickTableFieldFieldGlitchRate string = "glitch_rate"
+
+	// StickTableFieldFieldGlitchCnt captures enum value "glitch_cnt"
+	StickTableFieldFieldGlitchCnt string = "glitch_cnt"
 )
 
 // prop value enum

--- a/models/stick_table_entry.go
+++ b/models/stick_table_entry.go
@@ -58,6 +58,12 @@ type StickTableEntry struct {
 	// exp
 	Exp *int64 `json:"exp,omitempty"`
 
+	// glitch cnt
+	GlitchCnt *int64 `json:"glitch_cnt,omitempty"`
+
+	// glitch rate
+	GlitchRate *int64 `json:"glitch_rate,omitempty"`
+
 	// gpc0
 	Gpc0 *int64 `json:"gpc0,omitempty"`
 

--- a/models/stick_table_entry_compare.go
+++ b/models/stick_table_entry_compare.go
@@ -56,6 +56,14 @@ func (s StickTableEntry) Equal(t StickTableEntry, opts ...Options) bool {
 		return false
 	}
 
+	if !equalPointers(s.GlitchCnt, t.GlitchCnt) {
+		return false
+	}
+
+	if !equalPointers(s.GlitchRate, t.GlitchRate) {
+		return false
+	}
+
 	if !equalPointers(s.Gpc0, t.Gpc0) {
 		return false
 	}
@@ -157,6 +165,14 @@ func (s StickTableEntry) Diff(t StickTableEntry, opts ...Options) map[string][]i
 
 	if !equalPointers(s.Exp, t.Exp) {
 		diff["Exp"] = []interface{}{ValueOrNil(s.Exp), ValueOrNil(t.Exp)}
+	}
+
+	if !equalPointers(s.GlitchCnt, t.GlitchCnt) {
+		diff["GlitchCnt"] = []interface{}{ValueOrNil(s.GlitchCnt), ValueOrNil(t.GlitchCnt)}
+	}
+
+	if !equalPointers(s.GlitchRate, t.GlitchRate) {
+		diff["GlitchRate"] = []interface{}{ValueOrNil(s.GlitchRate), ValueOrNil(t.GlitchRate)}
 	}
 
 	if !equalPointers(s.Gpc0, t.Gpc0) {

--- a/models/stick_table_entry_compare_test.go
+++ b/models/stick_table_entry_compare_test.go
@@ -94,6 +94,8 @@ func TestStickTableEntryEqualFalse(t *testing.T) {
 		result.ConnCur = Ptr(*sample.ConnCur + 1)
 		result.ConnRate = Ptr(*sample.ConnRate + 1)
 		result.Exp = Ptr(*sample.Exp + 1)
+		result.GlitchCnt = Ptr(*sample.GlitchCnt + 1)
+		result.GlitchRate = Ptr(*sample.GlitchRate + 1)
 		result.Gpc0 = Ptr(*sample.Gpc0 + 1)
 		result.Gpc0Rate = Ptr(*sample.Gpc0Rate + 1)
 		result.Gpc1 = Ptr(*sample.Gpc1 + 1)
@@ -194,6 +196,8 @@ func TestStickTableEntryDiffFalse(t *testing.T) {
 		result.ConnCur = Ptr(*sample.ConnCur + 1)
 		result.ConnRate = Ptr(*sample.ConnRate + 1)
 		result.Exp = Ptr(*sample.Exp + 1)
+		result.GlitchCnt = Ptr(*sample.GlitchCnt + 1)
+		result.GlitchRate = Ptr(*sample.GlitchRate + 1)
 		result.Gpc0 = Ptr(*sample.Gpc0 + 1)
 		result.Gpc0Rate = Ptr(*sample.Gpc0Rate + 1)
 		result.Gpc1 = Ptr(*sample.Gpc1 + 1)
@@ -214,7 +218,7 @@ func TestStickTableEntryDiffFalse(t *testing.T) {
 
 	for _, sample := range samples {
 		result := sample.a.Diff(sample.b)
-		if len(result) != 23 {
+		if len(result) != 25 {
 			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			a, err := json.Marshal(&sample.a)
 			if err != nil {
@@ -224,7 +228,7 @@ func TestStickTableEntryDiffFalse(t *testing.T) {
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			t.Errorf("Expected StickTableEntry to be different in 23 cases, but it is not (%d) %s %s", len(result), a, b)
+			t.Errorf("Expected StickTableEntry to be different in 25 cases, but it is not (%d) %s %s", len(result), a, b)
 		}
 	}
 }

--- a/runtime/stick_tables.go
+++ b/runtime/stick_tables.go
@@ -238,6 +238,16 @@ func parseStickTableEntry(output string) *models.StickTableEntry { //nolint:goco
 			if err == nil {
 				entry.BytesOutRate = &bytesOutRate
 			}
+		case key == "glitch_cnt":
+			glitchCnt, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+			if err == nil {
+				entry.GlitchCnt = &glitchCnt
+			}
+		case strings.HasPrefix(key, "glitch_rate("):
+			glitchRate, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+			if err == nil {
+				entry.GlitchRate = &glitchRate
+			}
 		case key == "use":
 			entry.Use = strings.TrimSpace(v) == "1"
 		case key == "exp":

--- a/specification/build/haproxy_spec.yaml
+++ b/specification/build/haproxy_spec.yaml
@@ -9447,6 +9447,8 @@ definitions:
                 - server_id
                 - sess_cnt
                 - sess_rate
+                - glitch_rate
+                - glitch_cnt
               type: string
             period:
               type: integer
@@ -9511,6 +9513,12 @@ definitions:
         type: integer
         x-nullable: true
       exp:
+        type: integer
+        x-nullable: true
+      glitch_cnt:
+        type: integer
+        x-nullable: true
+      glitch_rate:
         type: integer
         x-nullable: true
       gpc0:

--- a/specification/models/runtime/table.yaml
+++ b/specification/models/runtime/table.yaml
@@ -44,6 +44,8 @@ table:
               - server_id
               - sess_cnt
               - sess_rate
+              - glitch_rate
+              - glitch_cnt
           type:
             type: string
             enum: [rate, counter]

--- a/specification/models/runtime/table_entry.yaml
+++ b/specification/models/runtime/table_entry.yaml
@@ -70,3 +70,9 @@ table_entry:
       x-nullable: true
     use:
       type: boolean
+    glitch_cnt:
+      type: integer
+      x-nullable: true
+    glitch_rate:
+      type: integer
+      x-nullable: true


### PR DESCRIPTION
HAProxy recently added a new sticktable counter for "glitches". This PR adds support for those to the library.

If any changes are desired for inclusions in upstream (in particular in regards to style), I am happy to apply them