### PR TITLE
MINOR: Add option to skip a reload, when creating a SSL Certificate

### DIFF
--- a/specification/build/haproxy_spec.yaml
+++ b/specification/build/haproxy_spec.yaml
@@ -24210,6 +24210,7 @@ paths:
           name: file_upload
           type: file
           x-mimetype: text/plain
+        - $ref: '#/parameters/skip_reload'
         - $ref: '#/parameters/force_reload'
       responses:
         "201":


### PR DESCRIPTION
Based on Feedback in https://github.com/haproxytech/dataplaneapi/issues/365 there should be no reason why Creating a certificate can't skip a reload.