### PR TITLE
BUG/MINOR: use `int64` format for memory information

### DIFF
--- a/specification/build/haproxy_spec.yaml
+++ b/specification/build/haproxy_spec.yaml
@@ -8955,10 +8955,13 @@ definitions:
           mem_info:
             properties:
               dataplaneapi_memory:
+                format: int64
                 type: integer
               free_memory:
+                format: int64
                 type: integer
               total_memory:
+                format: int64
                 type: integer
             type: object
           os_string:

--- a/specification/models/general.yaml
+++ b/specification/models/general.yaml
@@ -50,10 +50,13 @@ info:
           properties:
             total_memory:
               type: integer
+              format: int64
             free_memory:
               type: integer
+              format: int64
             dataplaneapi_memory:
               type: integer
+              format: int64
         time:
           type: integer
           description: Current time in milliseconds since Epoch.


### PR DESCRIPTION
It defaults to `int32` when not specified, and that is not enough for modern machines with way more than 2 GB of memory.