### PR TITLE
BUG/MINOR: tune.bufsize parse as a number

### DIFF
--- a/configuration/global.go
+++ b/configuration/global.go
@@ -3416,7 +3416,7 @@ func serializeTuneBufferOptions(p parser.Parser, options *models.TuneBufferOptio
 	if err := serializeInt64Option(p, "tune.buffers.reserve", options.BuffersReserve); err != nil {
 		return err
 	}
-	if err := serializeSizeOption(p, "tune.bufsize", &options.Bufsize); err != nil {
+	if err := serializeInt64Option(p, "tune.bufsize", options.Bufsize); err != nil {
 		return err
 	}
 	if err := serializeSizeOption(p, "tune.bufsize.small", options.BufsizeSmall); err != nil {


### PR DESCRIPTION
Parse tune.bufsize as a number. Buffer size needs to be in bytes.