### PR TITLE
BUILD/MINOR: upgrade dependency mapstructure to supported fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-openapi/strfmt v0.23.0
 	github.com/go-openapi/swag v0.23.1
 	github.com/go-openapi/validate v0.24.0
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/renameio v1.0.1
@@ -16,7 +17,6 @@ require (
 	github.com/haproxytech/go-logger v1.1.0
 	github.com/json-iterator/go v1.1.12
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/sirkon/dst v0.26.4
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.14.0
@@ -35,6 +35,7 @@ require (
 	github.com/go-openapi/spec v0.21.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/go-openapi/swag v0.23.1 h1:lpsStH0n2ittzTnbaSloVZLuB5+fvSY/+hnagBjSNZ
 github.com/go-openapi/swag v0.23.1/go.mod h1:STZs8TbRvEQQKUA+JZNAm3EWlgaOBGpyFDqQnDHMef0=
 github.com/go-openapi/validate v0.24.0 h1:LdfDKwNbpB6Vn40xhTdNZAnfLECL81w+VX3BumrGD58=
 github.com/go-openapi/validate v0.24.0/go.mod h1:iyeX1sEufmv3nPbBdX3ieNviWnOZaJ1+zquzJEf2BAQ=
+github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
+github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/runtime/stats.go
+++ b/runtime/stats.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	"github.com/haproxytech/client-native/v6/models"
 )


### PR DESCRIPTION
Replace module [`github.com/mitchellh/mapstructure`](https://pkg.go.dev/github.com/mitchellh/mapstructure) with [`github.com/go-viper/mapstructure/v2`](https://pkg.go.dev/github.com/go-viper/mapstructure/v2).

Note: github.com/mitchellh/mapstructure is still referenced in dependencies of go-openapi packages, but this is already being fixed (see https://github.com/go-openapi/strfmt/pull/157 ) and will be released with the next `github.com/go-openapi/strfmt` release.

## Rationale

Module [`github.com/mitchellh/mapstructure`](https://pkg.go.dev/github.com/mitchellh/mapstructure) isn't supported anymore and the repository has been archived. Announcement: https://gist.github.com/mitchellh/90029601268e59a29e64e55bab1c5bdc The blessed fork is at [`github.com/go-viper/mapstructure/v2`](https://pkg.go.dev/github.com/go-viper/mapstructure/v2).

