### PR TITLE
BUG/MINOR: cert-info: enhance leaf certificate selection to include SAN

### DIFF
--- a/storage/cert-info.go
+++ b/storage/cert-info.go
@@ -160,7 +160,7 @@ func findLeafCertificate(certs []*x509.Certificate) (*x509.Certificate, error) {
 
 	// Find the starting certificate (a certificate whose issuer is not in the list)
 	for _, cert := range certs {
-		if !cert.IsCA && cert.Subject.CommonName != "" && !isIssuer[cert.Subject.String()] {
+		if !cert.IsCA && (cert.Subject.CommonName != "" || len(cert.DNSNames) != 0) && !isIssuer[cert.Subject.String()] {
 			return cert, nil
 		}
 	}


### PR DESCRIPTION
Extending the logic to check if both CommonName or SubjectAlternativeNames are not empty. This fixes the cases where names are too long and have no CN but only SAN.

cc https://github.com/haproxytech/client-native/issues/129