### PR TITLE
BUG/MINOR: runtime: Add missing reload socket command termination

### DIFF
--- a/runtime/runtime_single_client.go
+++ b/runtime/runtime_single_client.go
@@ -109,7 +109,7 @@ func (s *SingleRuntime) readFromSocket(command string, socket socketType) (strin
 			fullCommand = fmt.Sprintf("set severity-output number;@%v %s;quit\n", 1, command)
 		}
 	case masterSocket:
-		fullCommand = command + ";quit"
+		fullCommand = command + ";quit\n"
 	}
 
 	_, err = api.Write([]byte(fullCommand))


### PR DESCRIPTION
Fixes #124

With the added newline character the reload command sent to the master socket succeeds.